### PR TITLE
Allow lambdas to be passed as UnaryOp and BinaryOp

### DIFF
--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -2449,8 +2449,14 @@ def get_typed_op(op, dtype, dtype2=None, *, is_left_scalar=False, is_right_scala
             is_right_scalar=is_right_scalar,
             kind=kind,
         )
-    else:
-        raise TypeError(f"Unable to get typed operator from object with type {type(op)}")
+    elif isinstance(op, FunctionType):
+        if kind == "unary":
+            op = UnaryOp.register_anonymous(op, is_udt=True)
+            return op._compile_udt(dtype, dtype2)
+        elif kind.startswith("binary"):
+            op = BinaryOp.register_anonymous(op, is_udt=True)
+            return op._compile_udt(dtype, dtype2)
+    raise TypeError(f"Unable to get typed operator from object with type {type(op)}")
 
 
 def find_opclass(gb_op):

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1998,3 +1998,19 @@ def test_reposition(v):
         result = v.reposition(offset, size=10).new()
         expected = get_expected(offset, 10)
         assert result.isequal(expected)
+
+
+def test_lambda_udfs(v):
+    result = v.apply(lambda x: x + 1).new()
+    expected = binary.plus(v, 1).new()
+    assert result.isequal(expected)
+    result = v.ewise_mult(v, lambda x, y: x + y).new()
+    expected = binary.plus(v & v).new()
+    assert result.isequal(expected)
+    result = v.ewise_add(v, lambda x, y: x + y, require_monoid=False).new()
+    assert result.isequal(expected)
+    # Should we also allow lambdas for monoids with assumed identity of 0?
+    with pytest.raises(TypeError):
+        v.ewise_add(v, lambda x, y: x + y)
+    with pytest.raises(TypeError):
+        v.inner(v, lambda x, y: x + y)


### PR DESCRIPTION
We could do Monoids too if we assumed identity of 0.

This uses the recent work on UDTs to compile only for the dtypes that we need, so it's actually fairly fast.

I think this is actually pretty nice!