### PR TITLE
Add `gb.binary.binom` to compute binomial coefficients.

### DIFF
--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -1190,6 +1190,43 @@ def _isclose(rel_tol=1e-7, abs_tol=0.0):
     return inner
 
 
+_MAX_INT64 = np.iinfo(np.int64).max
+
+
+def _binom(N, k):  # pragma: no cover
+    # Returns 0 if overflow or otherwise bad
+    if k > N or k < 0 or N == _MAX_INT64:
+        return 0
+    nterms = min(k, N - k)
+    N += 1
+    val = 1
+    for j in range(1, nterms + 1):
+        if val > _MAX_INT64 // (N - j):  # Overflow
+            return 0
+        val *= N - j
+        val //= j
+    return val
+
+
+# Kinda complicated, but works for now
+def _register_binom():
+    # "Fake" UDT so we only compile once for INT64
+    op = BinaryOp.register_new("binom", _binom, is_udt=True)
+    typed_op = op[INT64, INT64]
+    # Make this look like a normal operator
+    for dtype in [UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64]:
+        op.types[dtype] = INT64
+        op._typed_ops[dtype] = typed_op
+        if dtype != INT64:
+            op.coercions[dtype] = typed_op
+    # And make it not look like it operates on UDTs
+    typed_op._type2 = None
+    op._is_udt = False
+    op._udt_types = None
+    op._udt_ops = None
+    return op
+
+
 def _first(x, y):
     return x  # pragma: no cover
 
@@ -1671,6 +1708,10 @@ class BinaryOp(OpBase):
         BinaryOp.register_new("absfirst", _absfirst, lazy=True)
         BinaryOp.register_new("abssecond", _abssecond, lazy=True)
         BinaryOp.register_new("rpow", _rpow, lazy=True)
+
+        # For algorithms
+        binary._delayed["binom"] = (_register_binom, {})  # Lazy with custom creation
+        op._delayed["binom"] = binary
 
         BinaryOp.register_new("isclose", _isclose, parameterized=True)
 

--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -1194,17 +1194,15 @@ _MAX_INT64 = np.iinfo(np.int64).max
 
 
 def _binom(N, k):  # pragma: no cover
-    # Returns 0 if overflow or otherwise bad
-    if k > N or k < 0 or N == _MAX_INT64:
+    # Returns 0 if overflow or out-of-bounds
+    if k > N or k < 0:
         return 0
-    nterms = min(k, N - k)
-    N += 1
-    val = 1
-    for j in range(1, nterms + 1):
-        if val > _MAX_INT64 // (N - j):  # Overflow
+    val = np.int64(1)
+    for i in range(min(k, N - k)):
+        if val > _MAX_INT64 // (N - i):  # Overflow
             return 0
-        val *= N - j
-        val //= j
+        val *= N - i
+        val //= i + 1
     return val
 
 

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -1198,3 +1198,11 @@ def test_binaryop_commute_exists():
             missing.add(commutes_to.name)
     if missing:
         raise AssertionError("Missing binaryops: " + ", ".join(sorted(missing)))
+
+
+def test_binom():
+    v = Vector.from_values([0, 1, 2], [3, 4, 5])
+    result = v.apply(binary.binom, 2).new()
+    expected = Vector.from_values([0, 1, 2], [3, 6, 10])
+    assert result.isequal(expected)
+    assert op.binom is binary.binom

--- a/graphblas/tests/test_operator_types.py
+++ b/graphblas/tests/test_operator_types.py
@@ -34,6 +34,7 @@ FCFP = frozenset(FC | FP)
 ALL = frozenset(NOFC | FC)
 POS = frozenset({INT32, INT64})
 NOBOOL = frozenset(ALL - BOOL)
+INT64 = frozenset({INT64})
 
 # fmt: off
 UNARY = {
@@ -67,6 +68,7 @@ BINARY = {
     },
     (BOOLINT, FP): {"ldexp"},
     (INT, INT): {"band", "bclr", "bget", "bor", "bset", "bshift", "bxnor", "bxor"},
+    (INT, INT64): {"binom"},
     (NOFC, BOOL): {"ge", "gt", "le", "lt", "lxnor"},
     (NOFC, FC): {"cmplx"},
     (NOFC, FP): {"atan2", "copysign", "fmod", "hypot", "remainder"},


### PR DESCRIPTION
This is needed to calculate transitivity of a graph.

This is a "nice" example that shows how to customize creation of UDFs.  On the other hand, it shows how bespoke and sensitive it is to do.

I wonder whether the return type should be `INT64` or `FP64`, since binomial coefficients can get quite large in general.  Or maybe we should add `FP64` to the valid types (input and output).