### PR TITLE
Add `sort=True` keyword to `to_values`.

### DIFF
--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -1736,8 +1736,8 @@ class TransposedMatrix:
         return self._matrix.dtype
 
     @wrapdoc(Matrix.to_values)
-    def to_values(self, dtype=None):
-        rows, cols, vals = self._matrix.to_values(dtype)
+    def to_values(self, dtype=None, *, sort=True):
+        rows, cols, vals = self._matrix.to_values(dtype, sort=sort)
         return cols, rows, vals
 
     @wrapdoc(Matrix.diag)

--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -277,11 +277,18 @@ class Matrix(BaseType):
         self._nrows = nrows.value
         self._ncols = ncols.value
 
-    def to_values(self, dtype=None):
+    def to_values(self, dtype=None, *, sort=True):
         """
         GrB_Matrix_extractTuples
         Extract the rows, columns and values as a 3-tuple of numpy arrays
+
+        If sort is True then the rows and columns will be lexicographically sorted
+        by rows then columns if sorted rowwise, else columns then rows if columnwise.
         """
+        if sort:
+            if backend != "suitesparse":
+                raise NotImplementedError()
+            self.wait()  # sort in SS
         nvals = self._nvals
         rows = _CArray(size=nvals, name="&rows_array")
         columns = _CArray(size=nvals, name="&columns_array")

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3341,3 +3341,18 @@ def test_reposition(A):
     result(A.S, binary.plus) << A.T.reposition(-1, 1)
     expected *= 2
     assert result.isequal(expected)
+
+
+def test_to_values_sort():
+    # How can we get a matrix to a jumbled state in SS so that export won't be sorted?
+    N = 1000000
+    r = np.unique(np.random.randint(N, size=100))
+    c = np.unique(np.random.randint(N, size=100))
+    expected_rows = r.copy()
+    np.random.shuffle(r)
+    np.random.shuffle(c)
+    A = Matrix.from_values(r, c, r, nrows=N, ncols=N)
+    rows, cols, values = A.to_values(sort=False)
+    A = Matrix.from_values(r, c, r, nrows=N, ncols=N)
+    rows, cols, values = A.to_values(sort=True)
+    assert_array_equal(rows, expected_rows)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3356,3 +3356,5 @@ def test_to_values_sort():
     A = Matrix.from_values(r, c, r, nrows=N, ncols=N)
     rows, cols, values = A.to_values(sort=True)
     assert_array_equal(rows, expected_rows)
+    rows, cols, values = A.T.to_values(sort=True)
+    assert_array_equal(cols, expected_rows)

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1998,3 +1998,17 @@ def test_reposition(v):
         result = v.reposition(offset, size=10).new()
         expected = get_expected(offset, 10)
         assert result.isequal(expected)
+
+
+def test_to_values_sort():
+    # How can we get a vector to a jumbled state in SS so that export won't be sorted?
+    N = 1000000
+    a = np.unique(np.random.randint(N, size=100))
+    expected = a.copy()
+    np.random.shuffle(a)
+    v = Vector.from_values(a, a, size=N)
+    indices, values = v.to_values(sort=False)
+    v = Vector.from_values(a, a, size=N)
+    indices, values = v.to_values(sort=True)
+    assert_array_equal(indices, expected)
+    assert_array_equal(values, expected)

--- a/graphblas/vector.py
+++ b/graphblas/vector.py
@@ -267,11 +267,17 @@ class Vector(BaseType):
         call("GrB_Vector_resize", [self, size])
         self._size = size.value
 
-    def to_values(self, dtype=None):
+    def to_values(self, dtype=None, *, sort=True):
         """
         GrB_Vector_extractTuples
         Extract the indices and values as a 2-tuple of numpy arrays
+
+        If sort is True, the indices is guaranteed to be sorted.
         """
+        if sort:
+            if backend != "suitesparse":
+                raise NotImplementedError()
+            self.wait()  # sort in SS
         nvals = self._nvals
         indices = _CArray(size=nvals, name="&index_array")
         values = _CArray(size=nvals, dtype=self.dtype, name="&values_array")


### PR DESCRIPTION
I find this especially true for Vectors.  SuiteSparse:GraphBLAS often sorts things, but this isn't guaranteed.  So, let's make it explicit, and promise to sort manually for future backends if necessary.