### PR TITLE
Allow dicts to be used as scalars for record dtypes.

### DIFF
--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3350,6 +3350,8 @@ def test_to_values_sort():
     N = 1000000
     r = np.unique(np.random.randint(N, size=100))
     c = np.unique(np.random.randint(N, size=100))
+    r = r[: c.size].copy()  # make sure same length
+    c = c[: r.size].copy()
     expected_rows = r.copy()
     np.random.shuffle(r)
     np.random.shuffle(c)

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -442,3 +442,10 @@ def test_concat(s):
     A = gb.ss.concat([[s], [s], [empty]])
     expected = Matrix.from_values([0, 1], [0, 0], 5, nrows=3, ncols=1)
     assert A.isequal(expected)
+
+
+def test_record_from_dict():
+    s = Scalar.from_value(
+        {"x": 1, "y": {"a": 2, "b": 3}}, dtype={"x": int, "y": {"a": int, "b": int}}
+    )
+    assert s == (1, (2, 3))


### PR DESCRIPTION
I think this makes it a little more convenient when dealing with property graphs.