### PR TITLE
Have `op.from_string` include aggregators (last priority)

### DIFF
--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -3211,6 +3211,7 @@ def op_from_string(string):
         semiring_from_string,
         indexunary_from_string,
         select_from_string,
+        aggregator_from_string,
     ]:
         try:
             return func(string)

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -1015,6 +1015,7 @@ def test_from_string():
     assert op.from_string("min.plus") is semiring.min_plus
     with pytest.raises(ValueError, match="Unknown op string"):
         op.from_string("min.plus.times")
+    assert op.from_string("count") is agg.count
 
     assert agg.from_string("count") is agg.count
     assert agg.from_string("|") is agg.any


### PR DESCRIPTION
Although aggregators aren't present in `gb.op`, `gb.op.from_string` often serves to "convert this string to the best operator-like thing".