### PR TITLE
Deprecate `require_monoid=` keyword

### DIFF
--- a/graphblas/_infixmethods.py
+++ b/graphblas/_infixmethods.py
@@ -12,7 +12,7 @@ def call_op(self, other, method, op, *, outer=False, union=False):
     types = {Matrix, TransposedMatrix, Vector}
     if type1 in types and type2 in types:
         if outer:
-            return self.ewise_add(other, op, require_monoid=False)
+            return self.ewise_add(other, op)
         elif union:
             return self.ewise_union(other, op, False, False)
         else:

--- a/graphblas/tests/test_infix.py
+++ b/graphblas/tests/test_infix.py
@@ -71,8 +71,8 @@ def test_ewise(v1, v2, A1, A2):
         expected = left.ewise_mult(right, op.minus).new()
         assert expected.isequal(op.minus(left & right).new())
 
-        expected = left.ewise_add(right, op.minus, require_monoid=False).new()
-        assert expected.isequal(op.minus(left | right, require_monoid=False).new())
+        expected = left.ewise_add(right, op.minus).new()
+        assert expected.isequal(op.minus(left | right).new())
         expr = left | right
         assert expr.nvals == expr.nvals  # tests caching of ._value
 
@@ -182,8 +182,8 @@ def test_bad_ewise(s1, v1, A1, A2):
     with raises(TypeError, match="not supported for FP64"):
         A1 &= A1
 
-    with raises(TypeError, match="require_monoid"):
-        op.minus(v1 | v1)
+    # with raises(TypeError, match="require_monoid"):
+    op.minus(v1 | v1)  # ok now
     with raises(TypeError):
         op.minus(v1 & v1, require_monoid=False)
     with raises(TypeError, match="Bad dtype"):

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -384,17 +384,17 @@ def test_ewise_add(A):
         [2, 0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
         [4, 3, 5, 3, 8, 5, 3, 7, 8, 3, 1, 7, 4],
     )
-    with pytest.raises(TypeError, match="require_monoid"):
-        A.ewise_add(B, binary.second)
+    # with pytest.raises(TypeError, match="require_monoid"):
+    A.ewise_add(B, binary.second)  # okay now
     # surprising that SECOND(x, empty) == x, which is why user
     # must opt-in to using binary ops in ewise_add
-    C = A.ewise_add(B, binary.second, require_monoid=False).new()
+    C = A.ewise_add(B, binary.second).new()
     assert C.isequal(result)
     C << A.ewise_add(B, monoid.max)
     assert C.isequal(result)
     C << A.ewise_add(B, binary.max)
     assert C.isequal(result)
-    with pytest.raises(TypeError, match="Expected type: Monoid"):
+    with pytest.raises(TypeError, match="Expected type: BinaryOp, Monoid"):
         A.ewise_add(B, semiring.max_minus)
 
 
@@ -3188,6 +3188,8 @@ def test_deprecated(A):
         Scalar.new(int)
     with pytest.warns(DeprecationWarning):
         A.S.mask
+    with pytest.warns(DeprecationWarning):
+        binary.plus(A | A, require_monoid=True)
 
 
 def test_ndim(A):

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -225,7 +225,7 @@ def test_binaryop_parameterized():
     v0 = v.ewise_mult(v, op).new()
     r0 = Vector.from_values([0, 1, 3], [2, 4, -8], dtype=dtypes.INT32)
     assert v0.isequal(r0, check_dtype=True)
-    v1 = v.ewise_add(v, op(1), require_monoid=False).new()
+    v1 = v.ewise_add(v, op(1)).new()
     r1 = Vector.from_values([0, 1, 3], [3, 5, -7], dtype=dtypes.INT32)
     assert v1.isequal(r1, check_dtype=True)
 
@@ -396,7 +396,7 @@ def test_semiring_parameterized():
     B = A.mxm(A, mysemiring(1)).new()  # three extra pluses
     assert B.isequal(Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], [10, 12, 14, 16]))
 
-    with pytest.raises(TypeError, match="Expected type: Monoid"):
+    with pytest.raises(TypeError, match="Expected type: BinaryOp, Monoid"):
         A.ewise_add(A, mysemiring)
 
     # mismatched signatures.
@@ -531,7 +531,7 @@ def test_binaryop_udf():
     assert set(binary.bin_test_func.types) == comp_set
     v1 = Vector.from_values([0, 1, 3], [1, 2, -4], dtype=dtypes.INT32)
     v2 = Vector.from_values([0, 2, 3], [2, 3, 7], dtype=dtypes.INT32)
-    w = v1.ewise_add(v2, binary.bin_test_func, require_monoid=False).new()
+    w = v1.ewise_add(v2, binary.bin_test_func).new()
     result = Vector.from_values([0, 1, 2, 3], [-1, 2, 3, -31], dtype=dtypes.INT32)
     assert w.isequal(result)
 

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -374,15 +374,15 @@ def test_ewise_add(v):
     # Binary, Monoid, and Semiring
     v2 = Vector.from_values([0, 3, 5, 6], [2, 3, 2, 1])
     result = Vector.from_values([0, 1, 3, 4, 5, 6], [2, 1, 3, 2, 2, 1])
-    with pytest.raises(TypeError, match="require_monoid"):
-        v.ewise_add(v2, binary.minus)
+    # with pytest.raises(TypeError, match="require_monoid"):
+    v.ewise_add(v2, binary.minus)  # okay now
     w = v.ewise_add(v2, binary.max).new()  # ok if the binaryop is part of a monoid
     assert w.isequal(result)
-    w = v.ewise_add(v2, binary.max, require_monoid=False).new()
+    w = v.ewise_add(v2, binary.max).new()
     assert w.isequal(result)
     w.update(v.ewise_add(v2, monoid.max))
     assert w.isequal(result)
-    with pytest.raises(TypeError, match="Expected type: Monoid"):
+    with pytest.raises(TypeError, match="Expected type: BinaryOp, Monoid"):
         v.ewise_add(v2, semiring.max_times)
     # default is plus
     w = v.ewise_add(v2).new()
@@ -393,8 +393,8 @@ def test_ewise_add(v):
     b2 = Vector.from_values([0, 1, 2, 3], [True, True, False, False])
     with pytest.raises(KeyError, match="plus does not work"):
         b1.ewise_add(b2).new()
-    with pytest.raises(TypeError, match="for BOOL datatype"):
-        binary.plus(b1 | b2)
+    # with pytest.raises(TypeError, match="for BOOL datatype"):
+    binary.plus(b1 | b2)  # now okay (btw, `binary.plus[bool].monoid is None`)
 
 
 def test_extract(v):
@@ -1998,9 +1998,7 @@ def test_broadcasting(A, v):
     (A.dup(bool) & v.dup(bool)).new()  # okay
     with pytest.raises(TypeError):
         v += A
-    with pytest.raises(TypeError):
-        binary.minus(v | A)
-    binary.minus(v | A, require_monoid=False)
+    binary.minus(v | A)
 
 
 def test_ewise_union_infix():
@@ -2076,10 +2074,10 @@ def test_lambda_udfs(v):
     result = v.ewise_mult(v, lambda x, y: x + y).new()
     expected = binary.plus(v & v).new()
     assert result.isequal(expected)
-    result = v.ewise_add(v, lambda x, y: x + y, require_monoid=False).new()
+    result = v.ewise_add(v, lambda x, y: x + y).new()
     assert result.isequal(expected)
     # Should we also allow lambdas for monoids with assumed identity of 0?
-    with pytest.raises(TypeError):
-        v.ewise_add(v, lambda x, y: x + y)
+    # with pytest.raises(TypeError):
+    v.ewise_add(v, lambda x, y: x + y)  # now okay
     with pytest.raises(TypeError):
         v.inner(v, lambda x, y: x + y)


### PR DESCRIPTION
@jim22k you know my thoughts on `require_monoid=`.  In practice, it's super-duper annoying.  We proceeded conservatively: it's easier to relax than constrict, and I think it's now time to relax this.

More code cleanup will be possible once we actually remove it.