### PR TITLE
Add a few missing numpy ufuncs: cbrt, float_power, positive

### DIFF
--- a/graphblas/binary/numpy.py
+++ b/graphblas/binary/numpy.py
@@ -2,7 +2,7 @@
 
 See list of numpy ufuncs supported by numpy here:
 
-https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#math-operations
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
 import numpy as _np
@@ -23,6 +23,7 @@ _binary_names = {
     "true_divide",
     "floor_divide",
     "power",
+    "float_power",
     "remainder",
     "mod",
     "fmod",
@@ -85,6 +86,7 @@ _numpy_to_graphblas = {
     # "mod": "remainder",  # not the same!
     "not_equal": "ne",
     "power": "pow",
+    "float_power": "pow",  # we need to coerce everything to float64
     # "remainder": "remainder",  # not the same!
     "subtract": "minus",
     "true_divide": "truediv",
@@ -138,7 +140,29 @@ def __getattr__(name):
     if name not in _binary_names:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     if _config.get("mapnumpy") and name in _numpy_to_graphblas:
-        globals()[name] = getattr(_binary, _numpy_to_graphblas[name])
+        if name == "float_power":
+            from .. import operator
+
+            new_op = operator.BinaryOp(name)
+            builtin_op = _binary.pow
+            for dtype in builtin_op.types:
+                if dtype.name in {"FP32", "FC32", "FC64"}:
+                    orig_dtype = dtype
+                else:
+                    orig_dtype = operator.FP64
+                orig_op = builtin_op[orig_dtype]
+                cur_op = operator.TypedBuiltinBinaryOp(
+                    new_op,
+                    new_op.name,
+                    dtype,
+                    builtin_op.types[orig_dtype],
+                    orig_op.gb_obj,
+                    orig_op.gb_name,
+                )
+                new_op._add(cur_op)
+            globals()[name] = new_op
+        else:
+            globals()[name] = getattr(_binary, _numpy_to_graphblas[name])
     else:
         from .. import operator
 

--- a/graphblas/monoid/numpy.py
+++ b/graphblas/monoid/numpy.py
@@ -2,7 +2,7 @@
 
 See list of numpy ufuncs supported by numpy here:
 
-https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#math-operations
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
 import numpy as _np

--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -989,7 +989,7 @@ class UnaryOp(OpBase):
                 "|ASINH|ATANH|SIGNUM|CEIL|FLOOR|ROUND|TRUNC|EXP2|EXPM1|LOG10|LOG1P)"
                 "_(FP32|FP64|FC32|FC64)$"
             ),
-            re.compile("^GxB_(LGAMMA|TGAMMA|ERF|ERFC|FREXPX|FREXPE)_(FP32|FP64)$"),
+            re.compile("^GxB_(LGAMMA|TGAMMA|ERF|ERFC|FREXPX|FREXPE|CBRT)_(FP32|FP64)$"),
             re.compile("^GxB_(IDENTITY|AINV|MINV|ONE|CONJ)_(FC32|FC64)$"),
         ],
         "re_exprs_return_bool": [

--- a/graphblas/semiring/numpy.py
+++ b/graphblas/semiring/numpy.py
@@ -2,7 +2,7 @@
 
 See list of numpy ufuncs supported by numpy here:
 
-https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#math-operations
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
 import itertools as _itertools
@@ -43,6 +43,7 @@ _semiring_names -= {
             "arctan2",
             "copysign",
             "divide",
+            "float_power",
             "hypot",
             "ldexp",
             "logaddexp2",

--- a/graphblas/tests/test_numpyops.py
+++ b/graphblas/tests/test_numpyops.py
@@ -53,7 +53,7 @@ def test_npunary():
         data.append(
             [Vector.from_values(L, L, dtype="FC64"), np.array(L, dtype=np.complex128)],
         )
-    blocklist = {"BOOL": {"negative", "sign"}, "FC64": {"ceil", "floor", "trunc"}}
+    blocklist = {"BOOL": {"negative", "positive", "sign"}, "FC64": {"ceil", "floor", "trunc"}}
     isclose = graphblas.binary.isclose(1e-7, 0)
     for gb_input, np_input in data:
         for unary_name in sorted(npunary._unary_names):

--- a/graphblas/unary/numpy.py
+++ b/graphblas/unary/numpy.py
@@ -2,7 +2,7 @@
 
 See list of numpy ufuncs supported by numpy here:
 
-https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#math-operations
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
 import numpy as _np
@@ -18,6 +18,7 @@ _unary_names = {
     "negative",
     "abs",
     "absolute",
+    "cbrt",
     "fabs",
     "rint",
     "sign",
@@ -28,6 +29,7 @@ _unary_names = {
     "log10",
     "expm1",
     "log1p",
+    "positive",
     "sqrt",
     "square",
     "reciprocal",
@@ -62,6 +64,8 @@ _unary_names = {
     "ceil",
     "trunc",
     "spacing",
+    # Datetime functions
+    # "nat",  # We need to see if our UDTs support datetime dtypes!
 }
 _numpy_to_graphblas = {
     "abs": "abs",
@@ -73,6 +77,7 @@ _numpy_to_graphblas = {
     "arctan": "atan",
     "arctanh": "atanh",
     "bitwise_not": "bnot",
+    # "cbrt": "cbrt",  # TODO: added in SuiteSparse:GraphBLAS 7.1.0
     "ceil": "ceil",
     "cos": "cos",
     "cosh": "cosh",
@@ -91,6 +96,7 @@ _numpy_to_graphblas = {
     "log2": "log2",
     "logical_not": "lnot",  # should we?  result_type not the same
     "negative": "ainv",
+    "positive": "identity",  # positive is supposed to check dtype, but doesn't in numba
     # "reciprocal": "minv",  # has differences.  We should investigate further.
     "rint": "round",
     # 'sign': 'signum'  # signum is float-only


### PR DESCRIPTION
Note that `cbrt` is coming in SuiteSparse:GraphBLAS 7.1.0 🎉 .

This came about b/c I noticed `cbrt` (the principal cube root; e.g., `cbrt(-8) == -2`) was missing when I wanted to use it in `graphblas-algorithms` for weighted clustering coefficients.

Also, I noticed the numba documentation we were pointing to is out of date.