### PR TITLE
Add `mask.new()`, which can merge two masks

### DIFF
--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -1,7 +1,6 @@
 import sys as _sys
 from importlib import import_module as _import_module
 
-from . import mask  # noqa
 from ._version import get_versions
 
 
@@ -61,6 +60,7 @@ _SPECIAL_ATTRS = {
     "infix",
     "io",
     "lib",
+    "mask",
     "matrix",
     "monoid",
     "op",

--- a/graphblas/expr.py
+++ b/graphblas/expr.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from . import lib, utils
 from .dtypes import _INDEX
-from .mask import Mask
 from .utils import _CArray, output_type
 
 
@@ -232,6 +231,8 @@ class IndexerResolver:
             try:
                 index = list(index)
             except Exception:
+                from .mask import Mask
+
                 if isinstance(index, Mask):
                     raise TypeError(
                         f"Invalid type for index: {typ.__name__}.\n"

--- a/graphblas/mask.py
+++ b/graphblas/mask.py
@@ -1,5 +1,11 @@
 import warnings
 
+from . import utils
+from .binary import land, lor, pair
+from .dtypes import BOOL
+from .select import valuene
+from .unary import one
+
 
 class Mask:
     __slots__ = "parent", "__weakref__"
@@ -33,6 +39,47 @@ class Mask:
             DeprecationWarning,
         )
         return self.parent
+
+    def new(self, dtype=None, *, complement=False, mask=None, name=None):
+        """Return a new object with True values determined by the mask.
+
+        The resulting object used as structural or value mask is equivalent to the original mask.
+
+        Efficiently merge two masks by passing a mask with the `mask=` argument.
+        This is equivalent to the following (but uses more efficient recipes):
+
+        >>> val = Matrix(...)
+        >>> val(self) << True
+        >>> val(mask, replace=True) << True
+
+        If `complement=` argument is True, then the *complement* will be returned.
+        This is equivalent to the following (but uses more efficient recipes):
+
+        >>> val = Matrix(...)
+        >>> val(~self) << True
+        >>> val(~mask) << True
+
+        """
+        if dtype is None:
+            dtype = BOOL
+        if mask is None:
+            val = type(self.parent)(dtype, *self.parent.shape, name=name)
+            if complement:
+                val(~self) << True
+            else:
+                val(self) << True
+            return val
+        d = _COMPLEMENT_MASKS if complement else _COMBINE_MASKS
+        try:
+            func = d[type(self), type(mask)]
+        except KeyError:
+            from .base import _check_mask
+
+            try:
+                _check_mask(mask)
+            except Exception as exc:
+                raise exc from None
+        return func(self, mask, dtype, name)
 
 
 class StructuralMask(Mask):
@@ -105,3 +152,218 @@ class ComplementedValueMask(Mask):
     @property
     def _name_html(self):
         return f"~{self.parent._name_html}.V"
+
+
+# Recipes to combine two masks.
+# Legend:
+#    A: any
+#    S: structural
+#    V: value
+#    CS: complemented structural
+#    CV: complemented value
+def _combine_S_S(m1, m2, dtype, name):
+    """S-S"""
+    return pair(one(m1.parent).new() & one(m2.parent).new()).new(dtype, name=name)
+
+
+def _combine_S_A(m1, m2, dtype, name):
+    """S-S, S-V, S-CS, S-CV"""
+    return one(m1.parent).new(dtype, mask=m2, name=name)
+
+
+def _combine_A_S(m1, m2, dtype, name):
+    """S-S, V-S, CS-S, CV-S"""
+    return one(m2.parent).new(dtype, mask=m1, name=name)
+
+
+def _combine_V_A(m1, m2, dtype, name):
+    """V-S, V-V, V-CS, V-CV"""
+    if isinstance(m2, ValueMask) and m1.parent._nvals > m2.parent._nvals:
+        m1, m2 = m2, m1
+    val = valuene(m1.parent).new(dtype, mask=m2, name=name)
+    if dtype != BOOL or not val.ss.is_iso:
+        val(val.S) << True
+    return val
+
+
+def _combine_A_V(m1, m2, dtype, name):
+    """S-V, V-V, CS-V, CV-V"""
+    val = valuene(m2.parent).new(dtype, mask=m1, name=name)
+    if dtype != BOOL or not val.ss.is_iso:
+        val(val.S) << True
+    return val
+
+
+def _combine_CS_CS(m1, m2, dtype, name):
+    """CS-CS"""
+    val = pair(m1.parent | m2.parent).new(dtype, name=name)
+    val(~val.S, replace=True) << True
+    return val
+
+
+def _combine_CS_CV(m1, m2, dtype, name):
+    """CS-CV"""
+    val = pair(one(m1.parent).new() | m2.parent).new(dtype, name=name)
+    val(~val.V, replace=True) << True
+    return val
+
+
+def _combine_CV_CS(m1, m2, dtype, name):
+    """CV-CS"""
+    val = pair(m1.parent | one(m2.parent).new()).new(dtype, name=name)
+    val(~val.V, replace=True) << True
+    return val
+
+
+def _combine_CV_CV(m1, m2, dtype, name):
+    """CV-CV"""
+    val = lor(m1.parent | m2.parent).new(dtype, name=name)
+    val(~val.V, replace=True) << True
+    return val
+
+
+_COMBINE_MASKS = {
+    # S-S
+    (StructuralMask, StructuralMask): _combine_S_S,
+    # S-V, V-S
+    (StructuralMask, ValueMask): _combine_S_A,
+    (ValueMask, StructuralMask): _combine_A_S,
+    # S-CS, CS-S
+    (StructuralMask, ComplementedStructuralMask): _combine_S_A,
+    (ComplementedStructuralMask, StructuralMask): _combine_A_S,
+    # S-CV, CV-S
+    (StructuralMask, ComplementedValueMask): _combine_S_A,
+    (ComplementedValueMask, StructuralMask): _combine_A_S,
+    # V-V
+    (ValueMask, ValueMask): _combine_V_A,
+    # V-CS, CS-V
+    (ValueMask, ComplementedStructuralMask): _combine_V_A,
+    (ComplementedStructuralMask, ValueMask): _combine_A_V,
+    # V-CV, CV-V
+    (ValueMask, ComplementedValueMask): _combine_V_A,
+    (ComplementedValueMask, ValueMask): _combine_A_V,
+    # CS-CS
+    (ComplementedStructuralMask, ComplementedStructuralMask): _combine_CS_CS,
+    # CS-CV, CV-CS
+    (ComplementedStructuralMask, ComplementedValueMask): _combine_CS_CV,
+    (ComplementedValueMask, ComplementedStructuralMask): _combine_CV_CS,
+    # CV-CV
+    (ComplementedValueMask, ComplementedValueMask): _combine_CV_CV,
+}
+
+
+# Recipes to return the *complement* of combining two masks
+def _complement_S_S(m1, m2, dtype, name):
+    """S-S"""
+    val = pair(m1.parent & m2.parent).new(dtype, name=name)
+    val(~val.S, replace=True) << True
+    return val
+
+
+def _complement_S_A(m1, m2, dtype, name):
+    """S-S, S-V, S-CS, S-CV"""
+    val = one(m1.parent).new(dtype, mask=m2, name=name)
+    val(~val.S, replace=True) << True
+    return val
+
+
+def _complement_A_S(m1, m2, dtype, name):
+    """S-S, V-S, CS-S, CV-S"""
+    val = one(m2.parent).new(dtype, mask=m1, name=name)
+    val(~val.S, replace=True) << True
+    return val
+
+
+def _complement_V_V(m1, m2, dtype, name):
+    """V-V"""
+    val = land(m1.parent & m2.parent).new(dtype, name=name)
+    val(~val.V, replace=True) << True
+    return val
+
+
+def _complement_CS_CS(m1, m2, dtype, name):
+    """CS-CS"""
+    return pair(one(m1.parent).new() | one(m2.parent).new()).new(dtype, name=name)
+
+
+def _complement_CS_A(m1, m2, dtype, name):
+    """CS-S, CS-V, CS-CS, CS-CV"""
+    val = one(m1.parent).new(dtype, name=name)
+    val(~m2) << True
+    return val
+
+
+def _complement_A_CS(m1, m2, dtype, name):
+    """S-CS, V-CS, CS-CS, CV-CS"""
+    val = one(m2.parent).new(dtype, name=name)
+    val(~m1) << True
+    return val
+
+
+def _complement_CS_CV(m1, m2, dtype, name):
+    """CS-CV"""
+    val = pair(one(m1.parent).new() | m2.parent).new(dtype, name=name)
+    val(val.V, replace=True) << True
+    return val
+
+
+def _complement_CV_CS(m1, m2, dtype, name):
+    """CV-CS"""
+    val = pair(m1.parent | one(m2.parent).new()).new(dtype, name=name)
+    val(val.V, replace=True) << True
+    return val
+
+
+def _complement_CV_CV(m1, m2, dtype, name):
+    """CV-CV"""
+    val = lor(m1.parent | m2.parent).new(dtype, name=name)
+    val(val.V, replace=True) << True
+    return val
+
+
+def _complement_CV_A(m1, m2, dtype, name):
+    """CV-S, CV-V, CV-CS, CV-CV"""
+    val = one(m1.parent).new(dtype, mask=~m1, name=name)
+    val(~m2) << True
+    return val
+
+
+def _complement_A_CV(m1, m2, dtype, name):
+    """S-CV, V-CV, CS-CV, CV-CV"""
+    val = one(m2.parent).new(dtype, mask=~m2, name=name)
+    val(~m1) << True
+    return val
+
+
+_COMPLEMENT_MASKS = {
+    # S-S
+    (StructuralMask, StructuralMask): _complement_S_S,
+    # S-V, V-S
+    (StructuralMask, ValueMask): _complement_S_A,
+    (ValueMask, StructuralMask): _complement_A_S,
+    # S-CS, CS-S
+    (StructuralMask, ComplementedStructuralMask): _complement_A_CS,  # or _complement_S_A
+    (ComplementedStructuralMask, StructuralMask): _complement_CS_A,  # or _complement_A_S
+    # S-CV, CV-S
+    (StructuralMask, ComplementedValueMask): _complement_A_CV,  # or _complement_S_A
+    (ComplementedValueMask, StructuralMask): _complement_CV_A,  # or _complement_A_S
+    # V-V
+    (ValueMask, ValueMask): _complement_V_V,
+    # V-CS, CS-V
+    (ValueMask, ComplementedStructuralMask): _complement_A_CS,
+    (ComplementedStructuralMask, ValueMask): _complement_CS_A,
+    # V-CV, CV-V
+    (ValueMask, ComplementedValueMask): _complement_A_CV,
+    (ComplementedValueMask, ValueMask): _complement_CV_A,
+    # CS-CS
+    (ComplementedStructuralMask, ComplementedStructuralMask): _complement_CS_CS,
+    # CS-CV, CV-CS
+    (ComplementedStructuralMask, ComplementedValueMask): _complement_CS_CV,
+    (ComplementedValueMask, ComplementedStructuralMask): _complement_CV_CS,
+    # CV-CV
+    (ComplementedValueMask, ComplementedValueMask): _complement_CV_CV,
+}
+utils._output_types[StructuralMask] = StructuralMask
+utils._output_types[ValueMask] = ValueMask
+utils._output_types[ComplementedStructuralMask] = ComplementedStructuralMask
+utils._output_types[ComplementedValueMask] = ComplementedValueMask

--- a/graphblas/mask.py
+++ b/graphblas/mask.py
@@ -41,11 +41,23 @@ class Mask:
         return self.parent
 
     def new(self, dtype=None, *, complement=False, mask=None, name=None):
-        """Return a new object with True values determined by the mask.
+        """Return a new object with True values determined by the mask(s).
 
-        The resulting object used as structural or value mask is equivalent to the original mask.
+        By default, the result is True wherever the mask(s) would have been applied,
+        and empty otherwise.  If `complement` is True, then these are switched:
+        the result is empty where the mask(s) would have been applied, and True otherwise.
 
-        Efficiently merge two masks by passing a mask with the `mask=` argument.
+        In other words, these are equivalent if complement is False (and mask keyword is None):
+
+        >>> C(self) << expr
+        >>> C(result.S) << expr  # equivalent when complement is False
+
+        And these are equivalent if complement is True (and mask keyword is None):
+
+        >>> C(self) << expr
+        >>> C(~result.S) << expr  # equivalent when complement is True
+
+        This can also efficiently merge two masks by using the `mask=` argument.
         This is equivalent to the following (but uses more efficient recipes):
 
         >>> val = Matrix(...)
@@ -163,7 +175,7 @@ class ComplementedValueMask(Mask):
 #    CV: complemented value
 def _combine_S_S(m1, m2, dtype, name):
     """S-S"""
-    return pair(one(m1.parent).new() & one(m2.parent).new()).new(dtype, name=name)
+    return pair(m1.parent & m2.parent).new(dtype, name=name)
 
 
 def _combine_S_A(m1, m2, dtype, name):

--- a/graphblas/tests/test_core.py
+++ b/graphblas/tests/test_core.py
@@ -9,7 +9,7 @@ def test_import_special_attrs():
     assert len(not_hidden & graphblas._SPECIAL_ATTRS) == len(graphblas._SPECIAL_ATTRS)
     # Is everything special that needs to be?
     not_special = {x for x in dir(graphblas) if not x.startswith("_")} - graphblas._SPECIAL_ATTRS
-    assert not_special == {"backend", "config", "init", "mask", "replace"}
+    assert not_special == {"backend", "config", "init", "replace"}
     # Make sure these "not special" objects don't have objects that look special within them
     for attr in not_special:
         assert not set(dir(getattr(graphblas, attr))) & graphblas._SPECIAL_ATTRS

--- a/graphblas/tests/test_mask.py
+++ b/graphblas/tests/test_mask.py
@@ -1,0 +1,46 @@
+import itertools
+
+from pytest import raises
+
+from graphblas import Vector
+
+
+def test_mask_new():
+    for dtype, mask_dtype in itertools.product([None, bool, int], [bool, int]):
+        v1 = Vector(mask_dtype, size=10)
+        v1[3:6] = 0
+        v1[:3] = 10
+        v2 = Vector(mask_dtype, size=10)
+        v2[1::3] = 0
+        v2[::3] = 10
+        name = "howdy"
+        masks = [v1.S, v1.V, ~v1.S, ~v1.V, v2.S, v2.V, ~v2.S, ~v2.V]
+        for m1, m2 in itertools.product(masks, masks):
+            expected = Vector(bool if dtype is None else dtype, size=v1.size)
+            expected << True
+            expected = expected.dup(mask=m1).dup(mask=m2)
+            result = m1.new(dtype, mask=m2, name=name)
+            assert result.name == name
+            assert result.isequal(expected, check_dtype=True)
+            # Complemented
+            expected(~expected.S, replace=True) << True
+            result = m1.new(dtype, mask=m2, complement=True, name=name)
+            assert result.name == name
+            assert result.isequal(expected, check_dtype=True)
+        # w/o second mask
+        for m in masks:
+            expected.clear()
+            expected << True
+            expected = expected.dup(mask=m)
+            result = m.new(dtype, name=name)
+            assert result.name == name
+            assert result.isequal(expected, check_dtype=True)
+            # Complemented
+            expected(~expected.S, replace=True) << True
+            result = m.new(dtype, complement=True, name=name)
+            assert result.name == name
+            assert result.isequal(expected, check_dtype=True)
+        with raises(TypeError, match="Invalid mask"):
+            m.new(mask=object())
+        with raises(TypeError, match="Mask must indicate"):
+            m.new(mask=v1)

--- a/graphblas/tests/test_mask.py
+++ b/graphblas/tests/test_mask.py
@@ -1,11 +1,12 @@
 import itertools
 
-from pytest import raises
+import pytest
 
 from graphblas import Vector
 
 
-def test_mask_new():
+@pytest.mark.parametrize("as_matrix", [False, True])
+def test_mask_new(as_matrix):
     for dtype, mask_dtype in itertools.product([None, bool, int], [bool, int]):
         v1 = Vector(mask_dtype, size=10)
         v1[3:6] = 0
@@ -13,11 +14,16 @@ def test_mask_new():
         v2 = Vector(mask_dtype, size=10)
         v2[1::3] = 0
         v2[::3] = 10
+        if as_matrix:
+            v1 = v1._as_matrix()
+            v2 = v2._as_matrix()
         name = "howdy"
         masks = [v1.S, v1.V, ~v1.S, ~v1.V, v2.S, v2.V, ~v2.S, ~v2.V]
         for m1, m2 in itertools.product(masks, masks):
-            expected = Vector(bool if dtype is None else dtype, size=v1.size)
-            expected << True
+            expected = Vector(bool if dtype is None else dtype, size=10)
+            if as_matrix:
+                expected = expected._as_matrix()
+            expected[...] << True
             expected = expected.dup(mask=m1).dup(mask=m2)
             result = m1.new(dtype, mask=m2, name=name)
             assert result.name == name
@@ -30,7 +36,7 @@ def test_mask_new():
         # w/o second mask
         for m in masks:
             expected.clear()
-            expected << True
+            expected[...] << True
             expected = expected.dup(mask=m)
             result = m.new(dtype, name=name)
             assert result.name == name
@@ -40,7 +46,7 @@ def test_mask_new():
             result = m.new(dtype, complement=True, name=name)
             assert result.name == name
             assert result.isequal(expected, check_dtype=True)
-        with raises(TypeError, match="Invalid mask"):
+        with pytest.raises(TypeError, match="Invalid mask"):
             m.new(mask=object())
-        with raises(TypeError, match="Mask must indicate"):
+        with pytest.raises(TypeError, match="Mask must indicate"):
             m.new(mask=v1)

--- a/graphblas/utils.py
+++ b/graphblas/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import ffi, lib, mask
+from . import ffi, lib
 from .dtypes import _INDEX, lookup_dtype
 
 
@@ -38,11 +38,6 @@ _output_types = {
     # Mistakes
     object: object,
     type: type,
-    mask.Mask: mask.Mask,
-    mask.StructuralMask: mask.StructuralMask,
-    mask.ValueMask: mask.ValueMask,
-    mask.ComplementedStructuralMask: mask.ComplementedStructuralMask,
-    mask.ComplementedValueMask: mask.ComplementedValueMask,
 }
 _output_types.update((k, k) for k in np.cast)
 

--- a/scripts/test_imports.sh
+++ b/scripts/test_imports.sh
@@ -11,23 +11,6 @@ if ! python -c "from graphblas.op import plus" ; then exit 1 ; fi
 if ! python -c "from graphblas.select import tril" ; then exit 1 ; fi
 if ! python -c "from graphblas.semiring import plus_times" ; then exit 1 ; fi
 if ! python -c "from graphblas.unary import exp" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.agg.count" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.binary.plus" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.indexunary.tril" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.monoid.plus" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.op.plus" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.select.tril" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.semiring.plus_times" ; then exit 1 ; fi
-if ! python -c "import graphblas as gb ; gb.unary.exp" ; then exit 1 ; fi
-if ! python -c "from graphblas import agg ; agg.count" ; then exit 1 ; fi
-if ! python -c "from graphblas import binary ; binary.plus" ; then exit 1 ; fi
-if ! python -c "from graphblas import indexunary ; indexunary.tril" ; then exit 1 ; fi
-if ! python -c "from graphblas import monoid ; monoid.plus" ; then exit 1 ; fi
-if ! python -c "from graphblas import op ; op.plus" ; then exit 1 ; fi
-if ! python -c "from graphblas import select ; select.tril" ; then exit 1 ; fi
-if ! python -c "from graphblas import semiring ; semiring.plus_times" ; then exit 1 ; fi
-if ! python -c "from graphblas import unary ; unary.exp" ; then exit 1 ; fi
-
 if ! (for attr in Matrix Scalar Vector Recorder _agg agg base binary descriptor \
   dtypes exceptions expr ffi formatting infix init io lib mask matrix monoid \
   op operator scalar select semiring tests unary vector recorder _ss ss \
@@ -38,6 +21,14 @@ if ! (for attr in Matrix Scalar Vector Recorder _agg agg base binary descriptor 
     fi
   done
 ) ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.agg.count" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.binary.plus" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.indexunary.tril" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.monoid.plus" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.op.plus" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.select.tril" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.semiring.plus_times" ; then exit 1 ; fi
+if ! python -c "import graphblas as gb ; gb.unary.exp" ; then exit 1 ; fi
 if ! (for attr in _agg agg base binary binary.numpy descriptor dtypes exceptions \
   expr formatting infix io mask matrix monoid monoid.numpy op op.numpy operator scalar \
   select semiring semiring.numpy tests unary unary.numpy vector recorder _ss ss \
@@ -48,3 +39,11 @@ if ! (for attr in _agg agg base binary binary.numpy descriptor dtypes exceptions
     fi
   done
 ) ; then exit 1 ; fi
+if ! python -c "from graphblas import agg ; agg.count" ; then exit 1 ; fi
+if ! python -c "from graphblas import binary ; binary.plus" ; then exit 1 ; fi
+if ! python -c "from graphblas import indexunary ; indexunary.tril" ; then exit 1 ; fi
+if ! python -c "from graphblas import monoid ; monoid.plus" ; then exit 1 ; fi
+if ! python -c "from graphblas import op ; op.plus" ; then exit 1 ; fi
+if ! python -c "from graphblas import select ; select.tril" ; then exit 1 ; fi
+if ! python -c "from graphblas import semiring ; semiring.plus_times" ; then exit 1 ; fi
+if ! python -c "from graphblas import unary ; unary.exp" ; then exit 1 ; fi


### PR DESCRIPTION
Largely based on https://github.com/python-graphblas/python-graphblas/issues/234#issuecomment-1132304594

This does not yet make masks "value-y".

Light benchmarking was done to choose "good enough" recipes, but better recipes may exist.  The code is structured in a way that a recipe for any combination of masks may be easily updated.  This will help us improve a specific recipe if it's ever important for a benchmark.

This includes `complement=True` option to return the _complement_ of merged masks.

There have been times when I've wanted to do `.new()` on a mask.

Hopefully the results are intuitive.  I think they are.