### PR TITLE
Make aggregators callable.

### DIFF
--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1498,6 +1498,23 @@ def test_reduce_scalar(A):
     assert t == 48.23
 
 
+@autocompute
+def test_reduce_call_agg(A):
+    assert agg.sum(A) == 47
+    assert agg.sum(A.T) == 47
+    assert agg.sum(A + A) == 94  # handles expression
+    result = agg.max[float](A).new()  # typed agg is callable too
+    assert result.dtype == "FP64"
+    assert result == 8
+    expected = Vector.from_values([0, 1, 2, 3, 4, 5, 6], [5, 12, 1, 6, 7, 1, 15])
+    result = agg.sum(A, rowwise=True)
+    assert result.isequal(expected)
+    result = agg.sum(A.T, columnwise=True)
+    assert result.isequal(expected)
+    with pytest.raises(ValueError, match="cannot both be True"):
+        agg.sum(A, rowwise=True, columnwise=True)
+
+
 def test_transpose(A):
     # C << A.T
     rows, cols, vals = A.to_values()

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -876,6 +876,21 @@ def test_reduce_coerce_dtype(v):
     assert t == 5.23
 
 
+@autocompute
+def test_reduce_call_agg(v):
+    assert agg.sum(v) == 4
+    assert agg.sum(v + v) == 8  # handles expression
+    result = agg.max[float](v).new()  # typed agg is callable too
+    assert result.dtype == "FP64"
+    assert result == 2
+    with pytest.raises(ValueError, match="rowwise"):
+        agg.sum(v, rowwise=True)
+    with pytest.raises(ValueError, match="columnwise"):
+        agg.sum(v, columnwise=True)
+    with pytest.raises(TypeError):
+        agg.sum(7)
+
+
 def test_simple_assignment(v):
     # w[:] = v
     w = Vector(v.dtype, v.size)


### PR DESCRIPTION
By default, reduces argument to scalar, but `rowwise=` or `columnwise=` keyword may be used to reduce to vector.

Closes #238

This *does not* include `allow_empty=` keyword argument, which is available in `reduce` methods when reducing to scalar.  `allow_empty=False` only works on pure Monoid aggregators.  Also, we now have `.get` which makes it easier to get with a default value.