### PR TITLE
Allow `A << 1` to create dense matrices.

### DIFF
--- a/graphblas/base.py
+++ b/graphblas/base.py
@@ -396,19 +396,7 @@ class BaseType:
                                 "AmbiguousAssignOrExtract, and scalars."
                             ) from None
                     updater = self(mask=mask, accum=accum, replace=replace, input_mask=input_mask)
-                    if type(self) is Matrix:
-                        if mask is None:
-                            raise TypeError(
-                                "Warning: updating a Matrix with a scalar without a mask will "
-                                "make the Matrix dense.  This may use a lot of memory and probably "
-                                "isn't what you want.  Perhaps you meant:"
-                                "\n\n    M(M.S) << s\n\n"
-                                "If you do wish to make a dense matrix, then please be explicit:"
-                                "\n\n    M[:, :] = s"
-                            )
-                        updater[...] = scalar
-                    else:  # Vector
-                        updater[...] = scalar
+                    updater[...] = scalar
                     return
 
         if type(self) is not expr.output_type:

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -590,14 +590,14 @@ def test_assign(A):
     C = A.dup()
     C[:3:2, :6:5]() << B
     assert C.isequal(result)
-    with pytest.raises(TypeError, match="will make the Matrix dense"):
-        C << 1
     nvals = C.nvals
     C(C.S) << 1
     assert C.nvals == nvals
     assert C.reduce_scalar().new() == nvals
     with pytest.raises(TypeError, match="Invalid type for index"):
         C[C, [1]] = C
+    C << 1  # Now okay
+    assert C.nvals == C.nrows * C.ncols
 
 
 def test_assign_wrong_dims(A):


### PR DESCRIPTION
Now that SuiteSparse:GraphBLAS has iso-valued objects, I think it's okay to support this syntax.
Also, when reading or writing algorithms, I find that type-ambiguity isn't much of an issue.
So, I don't think the nuisance of raising this exception is worth the benefit anymore.