### PR TITLE
Allow boolean objects to be used as value masks

### DIFF
--- a/graphblas/base.py
+++ b/graphblas/base.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 from . import config, ffi
 from . import replace as replace_singleton
 from .descriptor import lookup as descriptor_lookup
+from .dtypes import BOOL
 from .exceptions import check_status
 from .expr import AmbiguousAssignOrExtract, Updater
 from .mask import Mask
@@ -170,14 +171,19 @@ AmbiguousAssignOrExtract._expect_type = _expect_type
 
 def _check_mask(mask, output=None):
     if not isinstance(mask, Mask):
-        if isinstance(mask, BaseType):
-            raise TypeError("Mask must indicate values (M.V) or structure (M.S)")
-        raise TypeError(f"Invalid mask: {type(mask)}")
-    if output is not None:
-        from .vector import Vector
-
-        if type(output) is Vector and type(mask.parent) is not Vector:
-            raise TypeError(f"Mask object must be type Vector; got {type(mask.parent)}")
+        # Convert bool objects to value masks
+        if output_type(mask).__name__ in {"Vector", "Matrix", "TransposedMatrix"}:
+            if mask.dtype != BOOL:
+                raise TypeError(
+                    f"Mask must be boolean objects (got {mask.dtype}) "
+                    "or indicate values (M.V) or structure (M.S)"
+                )
+            mask = mask.V  # auto-compute (will raise if disabled)
+        else:
+            raise TypeError(f"Invalid mask: {type(mask)}")
+    if output is not None and output.ndim == 1 and mask.parent.ndim != 1:
+        raise TypeError(f"Mask object must be type Vector; got {type(mask.parent)}")
+    return mask
 
 
 class BaseType:
@@ -194,7 +200,11 @@ class BaseType:
         for arg in optional_mask_accum_replace:
             if arg is replace_singleton:
                 replace = True
-            elif isinstance(arg, (BaseType, Mask)):
+            elif isinstance(arg, (BaseType, Mask)) or output_type(arg).__name__ in {
+                "Vector",
+                "Matrix",
+                "TransposedMatrix",
+            }:
                 if self._is_scalar:
                     raise TypeError("Mask not allowed for Scalars")
                 if mask_arg is not None:
@@ -226,13 +236,13 @@ class BaseType:
             elif self._is_scalar:
                 raise TypeError("input_mask not allowed for Scalars")
             else:
-                _check_mask(input_mask)
+                input_mask = _check_mask(input_mask)
         elif self._is_scalar:
             raise TypeError("Mask not allowed for Scalars")
         elif input_mask is not None:
             raise TypeError("mask and input_mask arguments cannot both be given")
         else:
-            _check_mask(mask)
+            mask = _check_mask(mask)
         if accum_arg is not None:
             if accum is not None:
                 raise TypeError("Got multiple values for argument 'accum'")
@@ -328,7 +338,7 @@ class BaseType:
                 if input_mask is not None:
                     if mask is not None:  # pragma: no cover (can this be covered?)
                         raise TypeError("mask and input_mask arguments cannot both be given")
-                    _check_mask(input_mask, output=expr.parent)
+                    input_mask = _check_mask(input_mask, expr.parent)
                     mask = expr._input_mask_to_mask(input_mask)
                     input_mask = None
                 expr = expr._extract_delayed()
@@ -425,7 +435,7 @@ class BaseType:
             complement = False
             structure = False
         else:
-            _check_mask(mask, self)
+            mask = _check_mask(mask, self)
             complement = mask.complement
             structure = mask.structure
 
@@ -570,7 +580,7 @@ class BaseExpression:
         elif mask is None:
             output.update(self)
         else:
-            _check_mask(mask, output)
+            mask = _check_mask(mask, output)
             output(mask=mask).update(self)
         return output
 

--- a/graphblas/base.py
+++ b/graphblas/base.py
@@ -172,7 +172,7 @@ AmbiguousAssignOrExtract._expect_type = _expect_type
 def _check_mask(mask, output=None):
     if not isinstance(mask, Mask):
         # Convert bool objects to value masks
-        if output_type(mask).__name__ in {"Vector", "Matrix", "TransposedMatrix"}:
+        if output_type(mask).__name__ in {"Vector", "Matrix"}:
             if mask.dtype != BOOL:
                 raise TypeError(
                     f"Mask must be boolean objects (got {mask.dtype}) "
@@ -203,7 +203,7 @@ class BaseType:
             elif isinstance(arg, (BaseType, Mask)) or output_type(arg).__name__ in {
                 "Vector",
                 "Matrix",
-                "TransposedMatrix",
+                "TransposedMatrix",  # Included here so we can give a better error message
             }:
                 if self._is_scalar:
                     raise TypeError("Mask not allowed for Scalars")

--- a/graphblas/binary/numpy.py
+++ b/graphblas/binary/numpy.py
@@ -168,7 +168,7 @@ def __getattr__(name):
 
         numpy_func = getattr(_np, name)
 
-        def func(x, y):
+        def func(x, y):  # pragma: no cover
             return numpy_func(x, y)
 
         operator.BinaryOp.register_new(f"numpy.{name}", func)

--- a/graphblas/binary/numpy.py
+++ b/graphblas/binary/numpy.py
@@ -167,7 +167,11 @@ def __getattr__(name):
         from .. import operator
 
         numpy_func = getattr(_np, name)
-        operator.BinaryOp.register_new(f"numpy.{name}", lambda x, y: numpy_func(x, y))
+
+        def func(x, y):
+            return numpy_func(x, y)
+
+        operator.BinaryOp.register_new(f"numpy.{name}", func)
     rv = globals()[name]
     if name in _commutative:
         rv._commutes_to = rv

--- a/graphblas/expr.py
+++ b/graphblas/expr.py
@@ -317,7 +317,7 @@ class AmbiguousAssignOrExtract:
                 raise TypeError("mask and input_mask arguments cannot both be given")
             from .base import _check_mask
 
-            _check_mask(input_mask, output=self.parent)
+            input_mask = _check_mask(input_mask, self.parent)
             mask = self._input_mask_to_mask(input_mask)
         delayed_extractor = self.parent._prep_for_extract(self.resolved_indexes)
         return delayed_extractor.new(dtype, mask=mask, name=name)

--- a/graphblas/mask.py
+++ b/graphblas/mask.py
@@ -81,16 +81,12 @@ class Mask:
             else:
                 val(self) << True
             return val
-        d = _COMPLEMENT_MASKS if complement else _COMBINE_MASKS
-        try:
-            func = d[type(self), type(mask)]
-        except KeyError:
-            from .base import _check_mask
 
-            try:
-                _check_mask(mask)
-            except Exception as exc:
-                raise exc from None
+        from .base import _check_mask
+
+        mask = _check_mask(mask)
+        d = _COMPLEMENT_MASKS if complement else _COMBINE_MASKS
+        func = d[type(self), type(mask)]
         return func(self, mask, dtype, name)
 
 

--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -1066,7 +1066,7 @@ class Matrix(BaseType):
             "reposition",
             None,
             [self, _reposition, (indices, chunk)],  # [*expr_args, func, args]
-            expr_repr="{2.name}.reposition(%d, %d)" % (row_offset, column_offset),
+            expr_repr="{0.name}.reposition(%d, %d)" % (row_offset, column_offset),
             nrows=nrows,
             ncols=ncols,
             dtype=self.dtype,

--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -517,7 +517,7 @@ class Matrix(BaseType):
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
-        if require_monoid:
+        if require_monoid:  # pragma: no cover
             if op.opclass != "BinaryOp" or op.monoid is None:
                 self._expect_op(
                     op,

--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 
-from . import _automethods, backend, binary, ffi, lib, monoid, select, semiring, utils
+from . import _automethods, backend, binary, config, ffi, lib, monoid, select, semiring, utils
 from ._ss.matrix import ss
 from .base import BaseExpression, BaseType, call
 from .dtypes import _INDEX, FP64, lookup_dtype, unify
@@ -1799,6 +1799,30 @@ class TransposedMatrix:
     @property
     def _name_html(self):
         return f"{self._matrix._name_html}.T"
+
+    @property
+    def S(self):
+        # I wonder if we could delay computing this and come up with faster recipes
+        if config.get("autocompute"):
+            return self.new().S
+        raise TypeError(
+            "S for masking not enabled for TransposedMatrix objects.  "
+            "Use `.new()` to create a new Matrix first.\n\n"
+            "Hint: use `graphblas.config.set(autocompute=True)` to enable "
+            "automatic computation of expressions."
+        )
+
+    @property
+    def V(self):
+        # I wonder if we could delay computing this and come up with faster recipes
+        if config.get("autocompute"):
+            return self.new().V
+        raise TypeError(
+            "V for masking not enabled for TransposedMatrix objects.  "
+            "Use `.new()` to create a new Matrix first.\n\n"
+            "Hint: use `graphblas.config.set(autocompute=True)` to enable "
+            "automatic computation of expressions."
+        )
 
     # Properties
     nrows = Matrix.ncols

--- a/graphblas/matrix.py
+++ b/graphblas/matrix.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 
-from . import _automethods, backend, binary, config, ffi, lib, monoid, select, semiring, utils
+from . import _automethods, backend, binary, ffi, lib, monoid, select, semiring, utils
 from ._ss.matrix import ss
 from .base import BaseExpression, BaseType, call
 from .dtypes import _INDEX, FP64, lookup_dtype, unify
@@ -1799,30 +1799,6 @@ class TransposedMatrix:
     @property
     def _name_html(self):
         return f"{self._matrix._name_html}.T"
-
-    @property
-    def S(self):
-        # I wonder if we could delay computing this and come up with faster recipes
-        if config.get("autocompute"):
-            return self.new().S
-        raise TypeError(
-            "S for masking not enabled for TransposedMatrix objects.  "
-            "Use `.new()` to create a new Matrix first.\n\n"
-            "Hint: use `graphblas.config.set(autocompute=True)` to enable "
-            "automatic computation of expressions."
-        )
-
-    @property
-    def V(self):
-        # I wonder if we could delay computing this and come up with faster recipes
-        if config.get("autocompute"):
-            return self.new().V
-        raise TypeError(
-            "V for masking not enabled for TransposedMatrix objects.  "
-            "Use `.new()` to create a new Matrix first.\n\n"
-            "Hint: use `graphblas.config.set(autocompute=True)` to enable "
-            "automatic computation of expressions."
-        )
 
     # Properties
     nrows = Matrix.ncols

--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -880,7 +880,7 @@ class OpBase:
         include_in_ops determines whether the operators are included in the
         `gb.ops` namespace in addition to the defined module.
         """
-        if cls._initialized:
+        if cls._initialized:  # pragma: no cover
             return
         # Read in the parse configs
         trim_from_front = cls._parse_config.get("trim_from_front", 0)
@@ -1183,7 +1183,7 @@ class UnaryOp(OpBase):
                     typed_op = op._typed_ops[target_type]
                     output_type = op.types[target_type]
                     for dtype in input_types:
-                        if dtype not in op.types:
+                        if dtype not in op.types:  # pragma: no branch
                             op.types[dtype] = output_type
                             op._typed_ops[dtype] = typed_op
                             op.coercions[dtype] = target_type
@@ -1354,7 +1354,7 @@ class IndexUnaryOp(OpBase):
             raise UdfParseError("Unable to parse function using Numba")
 
     def _compile_udt(self, dtype, dtype2):
-        if dtype2 is None:
+        if dtype2 is None:  # pragma: no cover
             dtype2 = dtype
         dtypes = (dtype, dtype2)
         if dtypes in self._udt_types:
@@ -1428,7 +1428,7 @@ class IndexUnaryOp(OpBase):
             op = getattr(indexunary, name)
             typed_op = op._typed_ops[BOOL]
             output_type = op.types[BOOL]
-            if UINT64 not in op.types:
+            if UINT64 not in op.types:  # pragma: no cover
                 op.types[UINT64] = output_type
                 op._typed_ops[UINT64] = typed_op
                 op.coercions[UINT64] = BOOL
@@ -1436,7 +1436,7 @@ class IndexUnaryOp(OpBase):
             op = getattr(indexunary, name)
             typed_op = op._typed_ops[INT64]
             output_type = op.types[INT64]
-            if UINT64 not in op.types:
+            if UINT64 not in op.types:  # pragma: no cover
                 op.types[UINT64] = output_type
                 op._typed_ops[UINT64] = typed_op
                 op.coercions[UINT64] = INT64
@@ -1549,7 +1549,7 @@ class SelectOp(OpBase):
 
     @classmethod
     def _initialize(cls):
-        if cls._initialized:
+        if cls._initialized:  # pragma: no cover
             return
         # IndexUnaryOp adds it boolean-returning objects to SelectOp
         IndexUnaryOp._initialize()
@@ -2087,7 +2087,7 @@ class BinaryOp(OpBase):
 
     @classmethod
     def _initialize(cls):
-        if cls._initialized:
+        if cls._initialized:  # pragma: no cover
             return
         super()._initialize()
         # Rename div to cdiv
@@ -2444,7 +2444,7 @@ class Monoid(OpBase):
 
     @classmethod
     def _initialize(cls):
-        if cls._initialized:
+        if cls._initialized:  # pragma: no cover
             return
         super()._initialize()
         lor = monoid.lor._typed_ops[BOOL]
@@ -2631,7 +2631,7 @@ class Semiring(OpBase):
 
     @classmethod
     def _initialize(cls):
-        if cls._initialized:
+        if cls._initialized:  # pragma: no cover
             return
         super()._initialize()
         # Rename div to cdiv (truncate towards 0)

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -15,16 +15,16 @@ def pytest_configure(config):
     randomly = config.getoption("--randomly", False)
     backend = config.getoption("--backend", "suitesparse")
     blocking = config.getoption("--blocking", True)
-    if blocking is None:
+    if blocking is None:  # pragma: no branch
         blocking = np.random.rand() < 0.5 if randomly else True
     record = config.getoption("--record", False)
-    if record is None:
+    if record is None:  # pragma: no branch
         record = np.random.rand() < 0.5 if randomly else False
     mapnumpy = config.getoption("--mapnumpy", False)
-    if mapnumpy is None:
+    if mapnumpy is None:  # pragma: no branch
         mapnumpy = np.random.rand() < 0.5 if randomly else False
     runslow = config.getoption("--runslow", False)
-    if runslow is None:
+    if runslow is None:  # pragma: no branch
         runslow = np.random.rand() < 0.25 if randomly else False
     config.runslow = runslow
 

--- a/graphblas/tests/test_mask.py
+++ b/graphblas/tests/test_mask.py
@@ -48,5 +48,8 @@ def test_mask_new(as_matrix):
             assert result.isequal(expected, check_dtype=True)
         with pytest.raises(TypeError, match="Invalid mask"):
             m.new(mask=object())
-        with pytest.raises(TypeError, match="Mask must indicate"):
-            m.new(mask=v1)
+        if v1.dtype == bool:
+            m.new(mask=v1)  # now okay
+        else:
+            with pytest.raises(TypeError, match="Mask must be"):
+                m.new(mask=v1)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3468,3 +3468,11 @@ def test_get(A):
     with pytest.raises(ValueError):
         # Not yet supported
         A.get(0, [0, 1])
+
+
+@autocompute
+def test_bool_as_mask(A):
+    expected = select.value(A < 3).new()
+    expected *= 3
+    A(A < 3, binary.plus, replace=True) << A + A
+    assert A.isequal(expected)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1110,6 +1110,8 @@ def test_apply_indexunary(A):
     assert w2.isequal(A3)
     assert w3.isequal(A3)
     assert w4.isequal(A3)
+    with pytest.raises(TypeError, match="left"):
+        A.apply(select.valueeq, left=s3)
 
 
 def test_select(A):
@@ -1136,8 +1138,11 @@ def test_select(A):
     )
     w7 = A.select("TRIU").new()
     assert w7.isequal(Aupper)
+    with pytest.raises(TypeError, match="thunk"):
+        A.select(select.valueeq, object())
 
 
+@pytest.mark.slow
 def test_indexunary_udf(A):
     def threex_minusthunk(x, row, col, thunk):  # pragma: no cover
         return 3 * x - thunk

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1139,7 +1139,7 @@ def test_select(A):
 
 
 def test_indexunary_udf(A):
-    def threex_minusthunk(x, row, col, thunk):
+    def threex_minusthunk(x, row, col, thunk):  # pragma: no cover
         return 3 * x - thunk
 
     indexunary.register_new("threex_minusthunk", threex_minusthunk)
@@ -1156,7 +1156,7 @@ def test_indexunary_udf(A):
     assert result.isequal(expected)
     delattr(indexunary, "threex_minusthunk")
 
-    def iii(x, row, col, thunk):
+    def iii(x, row, col, thunk):  # pragma: no cover
         return (row + col) // 2 >= thunk
 
     select.register_new("iii", iii)
@@ -1451,7 +1451,11 @@ def test_reduce_agg_empty():
 
 def test_reduce_row_udf(A):
     result = Vector.from_values([0, 1, 2, 3, 4, 5, 6], [5, 12, 1, 6, 7, 1, 15])
-    binop = graphblas.operator.BinaryOp.register_anonymous(lambda x, y: x + y)
+
+    def plus(x, y):  # pragma: no cover
+        return x + y
+
+    binop = graphblas.operator.BinaryOp.register_anonymous(plus)
     with pytest.raises(NotImplementedException):
         # Although allowed by the spec, SuiteSparse doesn't like user-defined binarops here
         A.reduce_rowwise(binop).new()
@@ -1666,9 +1670,9 @@ def test_transpose_exceptional():
 
     with pytest.raises(TypeError, match="not callable"):
         B.T(mask=A.V) << B.ewise_mult(B, op=binary.plus)
-    with pytest.raises(TypeError, match="autocompute"):
-        B(mask=A.T.S) << B.ewise_mult(B, op=binary.plus)
-    with pytest.raises(TypeError, match="autocompute"):
+    with pytest.raises(AttributeError):
+        B(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
+    with pytest.raises(AttributeError):
         B.T(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
     with pytest.raises(TypeError, match="does not support item assignment"):
         B.T[1, 0] << 10
@@ -2702,7 +2706,7 @@ def test_expr_is_like_matrix(A):
     assert attrs - infix_attrs == expected
     # TransposedMatrix is used differently than other expressions,
     # so maybe it shouldn't support everything.
-    assert attrs - transposed_attrs == (expected | {"ss", "to_pygraphblas"}) - {
+    assert attrs - transposed_attrs == (expected | {"S", "V", "ss", "to_pygraphblas"}) - {
         "_prep_for_extract",
         "_extract_element",
     }

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -342,8 +342,8 @@ def test_mxm_mask(A):
     assert C.isequal(result3)
     C2 = A.mxm(A, semiring.plus_times).new(mask=struct_mask.S)
     assert C2.isequal(result3)
-    with pytest.raises(TypeError, match="Mask must indicate"):
-        A.mxm(A).new(mask=struct_mask)
+    with pytest.raises(TypeError, match="Mask must be"):
+        A.mxm(A).new(mask=struct_mask)  # would be okay if bool mask, but it's not
 
 
 def test_mxm_accum(A):
@@ -523,9 +523,9 @@ def test_extract_input_mask():
         A[0, [0, 1]].new(input_mask=M.S, mask=expected.S)
     with pytest.raises(TypeError, match="mask and input_mask arguments cannot both be given"):
         A(input_mask=M.S, mask=expected.S)
-    with pytest.raises(TypeError, match=r"Mask must indicate values \(M.V\) or structure \(M.S\)"):
+    with pytest.raises(TypeError, match="Mask must be"):
         A[0, [0, 1]].new(input_mask=M)
-    with pytest.raises(TypeError, match=r"Mask must indicate values \(M.V\) or structure \(M.S\)"):
+    with pytest.raises(TypeError, match="Mask must be"):
         A(input_mask=M)
     with pytest.raises(TypeError, match="Mask object must be type Vector"):
         expected[[0, 1]].new(input_mask=M.S)
@@ -1666,9 +1666,9 @@ def test_transpose_exceptional():
 
     with pytest.raises(TypeError, match="not callable"):
         B.T(mask=A.V) << B.ewise_mult(B, op=binary.plus)
-    with pytest.raises(AttributeError):
-        B(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError, match="autocompute"):
+        B(mask=A.T.S) << B.ewise_mult(B, op=binary.plus)
+    with pytest.raises(TypeError, match="autocompute"):
         B.T(mask=A.T.V) << B.ewise_mult(B, op=binary.plus)
     with pytest.raises(TypeError, match="does not support item assignment"):
         B.T[1, 0] << 10
@@ -2702,7 +2702,7 @@ def test_expr_is_like_matrix(A):
     assert attrs - infix_attrs == expected
     # TransposedMatrix is used differently than other expressions,
     # so maybe it shouldn't support everything.
-    assert attrs - transposed_attrs == (expected | {"S", "V", "ss", "to_pygraphblas"}) - {
+    assert attrs - transposed_attrs == (expected | {"ss", "to_pygraphblas"}) - {
         "_prep_for_extract",
         "_extract_element",
     }

--- a/graphblas/tests/test_numpyops.py
+++ b/graphblas/tests/test_numpyops.py
@@ -35,7 +35,10 @@ def test_bool_doesnt_get_too_large():
         x, y = z.to_values()
         np.testing.assert_array_equal(y, (True, True, True, False))
 
-    op = graphblas.operator.UnaryOp.register_anonymous(lambda x: np.add(x, x))
+    def func(x):  # pragma: no cover
+        return np.add(x, x)
+
+    op = graphblas.operator.UnaryOp.register_anonymous(func)
     z = a.apply(op).new()
     x, y = z.to_values()
     np.testing.assert_array_equal(y, (True, False, True, False))

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -257,7 +257,11 @@ def test_binaryop_parameterized():
         BinaryOp.register_new("bad", object())
     assert not hasattr(binary, "bad")
     with pytest.raises(UdfParseError, match="Unable to parse function using Numba"):
-        BinaryOp.register_new("bad", lambda x, y: v)
+
+        def bad(x, y):  # pragma: no cover
+            return v
+
+        BinaryOp.register_new("bad", bad)
 
     def my_add(x, y):
         return x + y  # pragma: no cover
@@ -329,7 +333,11 @@ def test_monoid_parameterized():
     Monoid.register_new("_user_defined_monoid", bin_op, -np.inf)
     monoid = gb.monoid._user_defined_monoid
     fv2 = fv.ewise_mult(fv, monoid(2)).new()
-    plus1 = UnaryOp.register_anonymous(lambda x: x + 1)
+
+    def plus1(x):
+        return x + 1
+
+    plus1 = UnaryOp.register_anonymous(plus1)
     expected = fv.apply(plus1).new()
     assert fv2.isclose(expected, check_dtype=True)
     with pytest.raises(TypeError, match="must be a BinaryOp"):

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -334,7 +334,7 @@ def test_monoid_parameterized():
     monoid = gb.monoid._user_defined_monoid
     fv2 = fv.ewise_mult(fv, monoid(2)).new()
 
-    def plus1(x):
+    def plus1(x):  # pragma: no cover
         return x + 1
 
     plus1 = UnaryOp.register_anonymous(plus1)

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -129,6 +129,7 @@ def test_get_typed_op():
     assert operator.get_typed_op("+", dtypes.FP64, kind="monoid") is monoid.plus["FP64"]
     assert operator.get_typed_op("+[int64]", dtypes.FP64, kind="monoid") is monoid.plus["INT64"]
     assert operator.get_typed_op("+.*", dtypes.FP64, kind="semiring") is semiring.plus_times["FP64"]
+    assert operator.get_typed_op("row<=", dtypes.INT64, kind="select") is select.rowle["INT64"]
     with pytest.raises(ValueError, match="Unable to get op from string"):
         operator.get_typed_op("+", dtypes.FP64)
     assert (

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -687,7 +687,7 @@ def test_select(v):
 
 
 def test_indexunary_udf(v):
-    def twox_minusthunk(x, row, col, thunk):
+    def twox_minusthunk(x, row, col, thunk):  # pragma: no cover
         return 2 * x - thunk
 
     indexunary.register_new("twox_minusthunk", twox_minusthunk)
@@ -700,7 +700,7 @@ def test_indexunary_udf(v):
     assert result.isequal(expected)
     delattr(indexunary, "twox_minusthunk")
 
-    def ii(x, idx, _, thunk):
+    def ii(x, idx, _, thunk):  # pragma: no cover
         return idx // 2 >= thunk
 
     select.register_new("ii", ii)
@@ -2083,17 +2083,17 @@ def test_to_values_sort():
 
 
 def test_lambda_udfs(v):
-    result = v.apply(lambda x: x + 1).new()
+    result = v.apply(lambda x: x + 1).new()  # pragma: no branch
     expected = binary.plus(v, 1).new()
     assert result.isequal(expected)
-    result = v.ewise_mult(v, lambda x, y: x + y).new()
+    result = v.ewise_mult(v, lambda x, y: x + y).new()  # pragma: no branch
     expected = binary.plus(v & v).new()
     assert result.isequal(expected)
-    result = v.ewise_add(v, lambda x, y: x + y).new()
+    result = v.ewise_add(v, lambda x, y: x + y).new()  # pragma: no branch
     assert result.isequal(expected)
     # Should we also allow lambdas for monoids with assumed identity of 0?
     # with pytest.raises(TypeError):
-    v.ewise_add(v, lambda x, y: x + y)  # now okay
+    v.ewise_add(v, lambda x, y: x + y)  # now okay. pragma: no branch
     with pytest.raises(TypeError):
         v.inner(v, lambda x, y: x + y)
 

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2093,7 +2093,7 @@ def test_lambda_udfs(v):
     assert result.isequal(expected)
     # Should we also allow lambdas for monoids with assumed identity of 0?
     # with pytest.raises(TypeError):
-    v.ewise_add(v, lambda x, y: x + y)  # now okay. pragma: no branch
+    v.ewise_add(v, lambda x, y: x + y)  # pragma: no branch
     with pytest.raises(TypeError):
         v.inner(v, lambda x, y: x + y)
 

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -668,6 +668,8 @@ def test_apply_indexunary(v):
     assert w2.isequal(v2)
     assert w3.isequal(v2)
     assert w4.isequal(v2)
+    with pytest.raises(TypeError, match="left"):
+        v.apply(indexunary.valueeq, left=s2)
 
 
 def test_select(v):
@@ -684,8 +686,11 @@ def test_select(v):
     assert w4.isequal(result)
     assert w5.isequal(result)
     assert w6.isequal(result)
+    with pytest.raises(TypeError, match="thunk"):
+        v.select(select.valueeq, object())
 
 
+@pytest.mark.slow
 def test_indexunary_udf(v):
     def twox_minusthunk(x, row, col, thunk):  # pragma: no cover
         return 2 * x - thunk
@@ -695,6 +700,8 @@ def test_indexunary_udf(v):
     assert not hasattr(select, "twox_minusthunk")
     with pytest.raises(ValueError):
         select.register_anonymous(twox_minusthunk)
+    with pytest.raises(TypeError, match="must be a function"):
+        select.register_anonymous(object())
     expected = Vector.from_values([1, 3, 4, 6], [-2, -2, 0, -4], size=7)
     result = indexunary.twox_minusthunk(v, 4).new()
     assert result.isequal(expected)
@@ -725,6 +732,10 @@ def test_reduce(v):
     assert v.reduce(binary.plus).new() == 4
     with pytest.raises(TypeError, match="Expected type: Monoid"):
         v.reduce(binary.minus)
+    with pytest.raises(TypeError, match="to get the Monoid"):
+        v.reduce(semiring.plus_times)
+    with pytest.raises(TypeError, match="part of a Monoid for BOOL datatype"):
+        v.reduce(binary.plus[bool])
 
     # Test accum
     s(accum=binary.times) << v.reduce(monoid.plus)

--- a/graphblas/unary/numpy.py
+++ b/graphblas/unary/numpy.py
@@ -137,7 +137,7 @@ def __getattr__(name):
 
         numpy_func = getattr(_np, name)
 
-        def func(x):
+        def func(x):  # pragma: no cover
             return numpy_func(x)
 
         operator.UnaryOp.register_new(f"numpy.{name}", func)

--- a/graphblas/unary/numpy.py
+++ b/graphblas/unary/numpy.py
@@ -136,9 +136,16 @@ def __getattr__(name):
         from .. import operator
 
         numpy_func = getattr(_np, name)
-        operator.UnaryOp.register_new(f"numpy.{name}", lambda x: numpy_func(x))
+
+        def func(x):
+            return numpy_func(x)
+
+        operator.UnaryOp.register_new(f"numpy.{name}", func)
         if name == "reciprocal":
             # numba doesn't match numpy here
-            op = operator.UnaryOp.register_anonymous(lambda x: 1 if x else 0)
+            def reciprocal(x):
+                return 1 if x else 0
+
+            op = operator.UnaryOp.register_anonymous(reciprocal)
             globals()[name]._add(op["BOOL"])
     return globals()[name]

--- a/graphblas/vector.py
+++ b/graphblas/vector.py
@@ -470,7 +470,7 @@ class Vector(BaseType):
         """
         from .matrix import Matrix, MatrixExpression, TransposedMatrix
 
-        if require_monoid is not None:
+        if require_monoid is not None:  # pragma: no cover
             warnings.warn(
                 "require_monoid keyword is deprecated; "
                 "future behavior will be like `require_monoid=False`",
@@ -484,7 +484,7 @@ class Vector(BaseType):
         )
         op = get_typed_op(op, self.dtype, other.dtype, kind="binary")
         # Per the spec, op may be a semiring, but this is weird, so don't.
-        if require_monoid:
+        if require_monoid:  # pragma: no cover
             if op.opclass != "BinaryOp" or op.monoid is None:
                 self._expect_op(
                     op,


### PR DESCRIPTION
Was playing around a bit tonight and came up with this.  Sorry for taking "easier" work if anybody else had designs to implement this!

This is (1) in https://github.com/python-graphblas/python-graphblas/issues/234

An interesting side effect of applying our normal auto-compute rules is this gave `.S` and `.V` to `TransposedMatrix` objects, which required `config.get("autocompute")` to be true.  But, we don't need to add this.  Thoughts?  It's late, and I can't think.

Also, I'm not 100% sold on this PR, but I think it will be handy during the hands-on exploration phase.  I wonder whether this syntax will be used in "hardened" algorithms, or whether there will usually or always be faster recipes (that may not be obvious or as conveniently written) in practice.  I bet there are simple examples where this syntax is "the best", but, yeah, late, can't think.