### PR TITLE
Assign list to many indices, such as `v[[1, 2]] = [3, 4]`

### DIFF
--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -2164,7 +2164,7 @@ class ss:
         if bitmap is values:
             values = np.copy(values)
         if method == "import":
-            nrows, ncols = get_shape(nrows, ncols, values=values, bitmap=bitmap)
+            nrows, ncols = get_shape(nrows, ncols, dtype, bitmap=bitmap, values=values)
         else:
             nrows, ncols = matrix.shape
         Ab = ffi_new("int8_t**", ffi.from_buffer("int8_t*", bitmap))
@@ -2340,7 +2340,7 @@ class ss:
         if bitmap is values:
             values = np.copy(values)
         if method == "import":
-            nrows, ncols = get_shape(nrows, ncols, values=values, bitmap=bitmap)
+            nrows, ncols = get_shape(nrows, ncols, dtype, bitmap=bitmap, values=values)
         else:
             nrows, ncols = matrix.shape
         Ab = ffi_new("int8_t**", ffi.from_buffer("int8_t*", bitmap.T))
@@ -2496,7 +2496,7 @@ class ss:
             dtype = matrix.dtype
         values, dtype = values_to_numpy_buffer(values, dtype, copy=copy, order="C", ownable=True)
         if method == "import":
-            nrows, ncols = get_shape(nrows, ncols, values=values)
+            nrows, ncols = get_shape(nrows, ncols, dtype, values=values)
         else:
             nrows, ncols = matrix.shape
 
@@ -2643,7 +2643,7 @@ class ss:
             dtype = matrix.dtype
         values, dtype = values_to_numpy_buffer(values, dtype, copy=copy, order="F", ownable=True)
         if method == "import":
-            nrows, ncols = get_shape(nrows, ncols, values=values)
+            nrows, ncols = get_shape(nrows, ncols, dtype, values=values)
         else:
             nrows, ncols = matrix.shape
         Ax = ffi_new("void**", ffi.from_buffer("void*", values.T))

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -901,6 +901,8 @@ class ss:
         if nvals is None:
             if is_iso:
                 nvals = indices.size
+            elif dtype.np_type.subdtype is not None:
+                nvals = values.shape[0]
             else:
                 nvals = values.size
         if method == "import":
@@ -1066,6 +1068,8 @@ class ss:
         if size is None:
             if is_iso:
                 size = bitmap.size
+            elif dtype.np_type.subdtype is not None:
+                size = values.shape[0]
             else:
                 size = values.size
         if nvals is None:
@@ -1215,7 +1219,10 @@ class ss:
         vhandle = ffi_new("GrB_Vector*")
         vx = ffi_new("void**", ffi.from_buffer("void*", values))
         if size is None:
-            size = values.size
+            if dtype.np_type.subdtype is not None:
+                size = values.shape[0]
+            else:
+                size = values.size
         if method == "import":
             vhandle = ffi_new("GrB_Vector*")
             args = (dtype._carg, size)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1574,6 +1574,35 @@ def test_assign_transpose(A):
     assert C[: A.ncols, : A.nrows].new().isequal(A.T.new())
 
 
+def test_assign_list():
+    A = Matrix(int, 3, 3)
+    A[[0, 1], [1, 2]] = [[3, 4], [5, 6]]
+    expected = Matrix.from_values([0, 0, 1, 1], [1, 2, 1, 2], [3, 4, 5, 6], nrows=3, ncols=3)
+    assert A.isequal(expected)
+    A[[0, 1], 1] = np.arange(2)
+    expected = Matrix.from_values([0, 0, 1, 1], [1, 2, 1, 2], [0, 4, 1, 6], nrows=3, ncols=3)
+    assert A.isequal(expected)
+    A[0, 1:3] = [10, 20]
+    expected = Matrix.from_values([0, 0, 1, 1], [1, 2, 1, 2], [10, 20, 1, 6], nrows=3, ncols=3)
+    assert A.isequal(expected)
+    with pytest.raises(TypeError):
+        A[0, 1] = [0]
+    with pytest.raises(TypeError):
+        A()[0, 1] = [0]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], 1] = [0]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], [1, 2]] = [0]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], [1, 2]] = [1, 2, 3, 4]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1, 2], [1]] = [1, 2, 3]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1, 2], [1]] = [[1, 2, 3]]
+    with pytest.raises(TypeError):
+        A[[0, 1], [1, 2]] = [[3, 4], [5, object()]]
+
+
 def test_isequal(A, v):
     assert A.isequal(A)
     with pytest.raises(TypeError, match="Matrix"):
@@ -1870,14 +1899,10 @@ def test_import_export(A, do_iso, methods):
     d["bitmap"] = np.concatenate([d["bitmap"], d["bitmap"]], axis=0)
     B5b = Matrix.ss.import_any(**d)
     if in_method == "import":
-        if not do_iso:
-            assert B5b.isequal(A)
-            assert B5b.ss.is_iso is do_iso
-        else:
-            # B5b == [A, A]
-            assert B5b.nvals == 2 * A.nvals
-            assert B5b.nrows == 2 * A.nrows
-            assert B5b.ncols == A.ncols
+        # B5b == [A, A] (i.e, get 2d shape from bitmap first if possible)
+        assert B5b.nvals == 2 * A.nvals
+        assert B5b.nrows == 2 * A.nrows
+        assert B5b.ncols == A.ncols
     else:
         A5.ss.pack_any(**d)
         assert A5.isequal(A)
@@ -3371,6 +3396,15 @@ def test_udt():
     for aggop in [agg.first_index, agg.last_index]:
         A.reduce_rowwise(aggop).new()
         A.reduce_columnwise(aggop).new()
+    A.clear()
+    A[[0, 1], 1] = [(2, 3), (4, 5)]
+    expected = Matrix.from_values([0, 1], [1, 1], [(2, 3), (4, 5)], dtype=udt)
+    assert A.isequal(expected)
+    A.clear()
+    A[[0, 1], [1]] = [[(2, 3)], [(4, 5)]]
+    assert A.isequal(expected)
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], [1]] = [[(2, 3), (4, 5)]]
 
     np_dtype = np.dtype("(3,)uint16")
     udt = dtypes.register_anonymous(np_dtype, "has_subdtype")
@@ -3389,6 +3423,18 @@ def test_udt():
     info = A.ss.export("coor")
     result = A.ss.import_any(**info)
     assert result.isequal(A)
+    A.clear()
+    A[[0, 1], 1] = [(2, 3, 4), [5, 6, 7]]
+    expected = Matrix.from_values([0, 1], [1, 1], [[2, 3, 4], [5, 6, 7]], dtype=udt)
+    assert A.isequal(expected)
+    A[[0, 1], [1]] = [[[2, 3, 4]], [[5, 6, 7]]]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], [1]] = [[[2, 3, 4], [5, 6, 7]]]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        A[[0, 1], [1]] = [[2, 3, 4], [5, 6, 7]]
+    A = Matrix(udt, nrows=2, ncols=3)
+    with pytest.raises(ValueError, match="include dtype shape"):
+        A[[0, 1], :] = [[2, 3, 4], [5, 6, 7]]
 
 
 def test_reposition(A):

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -608,6 +608,28 @@ def test_assign_scalar_with_mask():
     assert v.isequal(result)
 
 
+def test_assign_list():
+    v = Vector(int, 4)
+    v[[0, 1]] = [2, 3]
+    expected = Vector.from_values([0, 1], [2, 3], size=4)
+    assert v.isequal(expected)
+    v[::2] = np.arange(2)
+    expected = Vector.from_values([0, 1, 2], [0, 3, 1], size=4)
+    assert v.isequal(expected)
+    with pytest.raises(TypeError):
+        v[0] = [1]
+    with pytest.raises(TypeError):
+        v()[0] = [1]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        v[[0, 1]] = [1, 2, 3]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        v[[0, 1]] = [[1, 2]]
+    with pytest.raises(ValueError, match="shape mismatch"):
+        v[[0, 1]] = [[1], [2]]
+    with pytest.raises(TypeError):
+        v[[0, 1]] = [2, object()]
+
+
 def test_apply(v):
     result = Vector.from_values([1, 3, 4, 6], [-1, -1, -2, 0])
     w = v.apply(unary.ainv).new()
@@ -1859,6 +1881,9 @@ def test_udt():
     assert result.isequal(v)
     for aggop in [agg.any_value, agg.first, agg.last, agg.count, agg.first_index, agg.last_index]:
         v.reduce(aggop).new()
+    v.clear()
+    v[[0, 1]] = [(2, 3), (4, 5)]
+    expected = Vector.from_values([0, 1], [(2, 3), (4, 5)], dtype=udt, size=v.size)
 
     # arrays as dtypes!
     np_dtype = np.dtype("(3,)uint16")
@@ -1904,6 +1929,10 @@ def test_udt():
     # Just make sure these work
     for aggop in [agg.any_value, agg.first, agg.last, agg.count, agg.first_index, agg.last_index]:
         v.reduce(aggop).new()
+    v.clear()
+    v[[0, 1]] = [[2, 3, 4], [5, 6, 7]]
+    expected = Vector.from_values([0, 1], [[2, 3, 4], [5, 6, 7]], dtype=udt2, size=v.size)
+    assert v.isequal(expected)
 
 
 def test_infix_outer():

--- a/graphblas/utils.py
+++ b/graphblas/utils.py
@@ -86,11 +86,18 @@ def values_to_numpy_buffer(array, dtype=None, *, copy=False, ownable=False, orde
     return array, dtype
 
 
-def get_shape(nrows, ncols, **arrays):
+def get_shape(nrows, ncols, dtype=None, **arrays):
     if nrows is None or ncols is None:
         # Get nrows and ncols from the first 2d array
-        arr = next((array for array in arrays.values() if array.ndim == 2), None)
-        if arr is None:
+        is_subarray = dtype.np_type.subdtype is not None
+        for name, arr in arrays.items():
+            if name == "values" and is_subarray:
+                # We could be smarter and determine the shape of the dtype sub-arrays
+                if arr.ndim >= 3:
+                    break
+            elif arr.ndim == 2:
+                break
+        else:
             raise ValueError(
                 "Either nrows and ncols must be provided, or one of the following arrays"
                 f'must be 2d (from which to get nrows and ncols): {", ".join(arrays)}'

--- a/graphblas/vector.py
+++ b/graphblas/vector.py
@@ -1059,13 +1059,46 @@ class Vector(BaseType):
                 dtype = self.dtype if self.dtype._is_udt else None
                 try:
                     value = Scalar.from_value(value, dtype, is_cscalar=None, name="")
-                except TypeError:
+                except (TypeError, ValueError):
+                    if size is not None:
+                        try:
+                            values, dtype = values_to_numpy_buffer(value, dtype, copy=True)
+                        except Exception:
+                            extra_message = "Literal scalars and lists also accepted."
+                        else:
+                            shape = values.shape
+                            try:
+                                vals = Vector.ss.import_full(
+                                    values, dtype=dtype, take_ownership=True
+                                )
+                                if dtype.np_type.subdtype is not None:
+                                    shape = vals.shape
+                            except Exception:
+                                vals = None
+                            if vals is None or shape != (size,):
+                                if dtype.np_type.subdtype is not None:
+                                    extra = (
+                                        " (this is assigning to a vector with sub-array dtype "
+                                        f"({dtype}), so array shape should include dtype shape)"
+                                    )
+                                else:
+                                    extra = ""
+                                raise ValueError(
+                                    f"shape mismatch: value array of shape {shape} "
+                                    f"does not match indexing of shape ({size},)"
+                                    f"{extra}"
+                                ) from None
+                            return self._prep_for_assign(
+                                resolved_indexes, vals, mask=mask, is_submask=is_submask
+                            )
+                    else:
+                        extra_message = "Literal scalars also accepted."
                     value = self._expect_type(
                         value,
                         (Scalar, Vector),
                         within=method_name,
                         argname="value",
-                        extra_message="Literal scalars also accepted.",
+                        extra_message=extra_message,
                     )
             if is_submask:
                 if size is None:


### PR DESCRIPTION
Closes #245.  This also fixes some import functions for sub-array UDTs.
Shapes must match exactly.  We aren't forgiving or do broadcasing like NumPy.

I agree in principle that *if* we were to allow operations between
e.g. vectors and numpy arrays or lists (such as `binary.min(v & a)`),
then we should probably be consistent with how we treat
lists/arrays/etc as vectors or matrices when assigning.
I think we should treat them as dense in all cases.

I don't think using a list to assign multiple items at a time *implies*
that a list or array should be treated as vectors or matrices elsewhere.
The mental model is that it's assigning multiple elements.  That's it.
That we convert it to a Vector or Matrix is an implementation detail.

I think assigning lists/arrays is intuitive, and useful in an interactive,
educational setting.  It's plausible that it will be useful in practice too
to conveniently and efficiently assign arrays to sub-vector/sub-matrices.

Adding this functionality was pretty straightforward and very isolated.
Most of the code is to enable good error messages and handling sub-array UDTs.