### PR TITLE
Rewrite `A.select(A < 7)` to a select expression

### DIFF
--- a/graphblas/operator.py
+++ b/graphblas/operator.py
@@ -3068,6 +3068,23 @@ monoid.register_anonymous = Monoid.register_anonymous
 semiring.register_new = Semiring.register_new
 semiring.register_anonymous = Semiring.register_anonymous
 
+select._binary_to_select.update(
+    {
+        binary.eq: select.valueeq,
+        binary.ne: select.valuene,
+        binary.le: select.valuele,
+        binary.lt: select.valuelt,
+        binary.ge: select.valuege,
+        binary.gt: select.valuegt,
+        binary.iseq: select.valueeq,
+        binary.isne: select.valuene,
+        binary.isle: select.valuele,
+        binary.islt: select.valuelt,
+        binary.isge: select.valuege,
+        binary.isgt: select.valuegt,
+    }
+)
+
 _str_to_unary = {
     "-": unary.ainv,
     "~": unary.lnot,

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -1140,9 +1140,18 @@ def test_select(A):
     assert w7.isequal(Aupper)
     with pytest.raises(TypeError, match="thunk"):
         A.select(select.valueeq, object())
+
+
+@autocompute
+def test_select_bools_and_masks(A):
+    A3 = Matrix.from_values([0, 3, 3, 6], [3, 0, 2, 4], [3, 3, 3, 3], nrows=7, ncols=7)
     # Select with boolean and masks
     w8 = A.select((A == 3).new()).new()
     assert w8.isequal(A3)
+    w8b = A.select(A == 3).new()  # we rewrite!
+    assert w8b.isequal(A3)
+    w8c = A.select(~(A != 3)).new()
+    assert w8c.isequal(A3)
     w9 = A.select(w8.S).new()
     assert w9.isequal(A3)
     w8[0, 1] = 0
@@ -1150,6 +1159,8 @@ def test_select(A):
     assert w10.isequal(A3)
     with pytest.raises(TypeError, match="thunk"):
         A.select(w8.V, 777)
+    with pytest.raises(TypeError, match="thunk"):
+        A.select(A == 3, 777)
     with pytest.raises(TypeError):
         A.select(A[0, :].new().S)
 

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -688,9 +688,18 @@ def test_select(v):
     assert w6.isequal(result)
     with pytest.raises(TypeError, match="thunk"):
         v.select(select.valueeq, object())
+
+
+@autocompute
+def test_select_bools_and_masks(v):
     # Select with boolean and masks
+    result = Vector.from_values([1, 3], [1, 1], size=7)
     w7 = v.select((v == 1).new()).new()
     assert w7.isequal(result)
+    w7b = v.select(v == 1).new()  # we rewrite!
+    assert w7b.isequal(result)
+    w7c = v.select(~(v != 1)).new()
+    assert w7c.isequal(result)
     w8 = v.select(w7.S).new()
     assert w8.isequal(result)
     w7[4] = 0
@@ -698,6 +707,8 @@ def test_select(v):
     assert w9.isequal(result)
     with pytest.raises(TypeError, match="thunk"):
         v.select(w7.V, 777)
+    with pytest.raises(TypeError, match="thunk"):
+        v.select(v == 1, 777)
     with pytest.raises(TypeError):
         v.select(v.outer(v).new().S)
     # Make sure we use `replace`


### PR DESCRIPTION
Straightforward pattern-match and rewrite.  This is an optimization of (4) from #234 and #251.