### PR TITLE
Add SuiteSparse:GraphBLAS (de)serialize

### DIFF
--- a/graphblas/_ss/descriptor.py
+++ b/graphblas/_ss/descriptor.py
@@ -1,0 +1,78 @@
+from graphblas import ffi, lib
+from graphblas.descriptor import Descriptor, _desc_map
+from graphblas.exceptions import check_status
+
+str_to_compression = {
+    "none": lib.GxB_COMPRESSION_NONE,
+    "default": lib.GxB_COMPRESSION_DEFAULT,
+    "lz4": lib.GxB_COMPRESSION_LZ4,
+    "lz4hc": lib.GxB_COMPRESSION_LZ4HC,
+}
+
+
+def get_nthreads_descriptor(nthreads, _cache=True):
+    nthreads = max(0, int(nthreads))
+    key = ("nthreads", nthreads)
+    if _cache and key in _desc_map:
+        return _desc_map[key]
+    desc_obj = ffi.new("GrB_Descriptor*")
+    lib.GrB_Descriptor_new(desc_obj)
+    desc = Descriptor(desc_obj[0], f"nthreads{nthreads}")
+    check_status(
+        lib.GxB_Desc_set(
+            desc._carg,
+            lib.GxB_NTHREADS,
+            ffi.cast("GrB_Desc_Value", nthreads),
+        ),
+        desc,
+    )
+    if _cache:
+        _cache[key] = desc
+    return desc
+
+
+def get_compression_descriptor(compression="default", level=None, nthreads=None):
+    if compression is None:
+        comp = str_to_compression["none"]
+    elif not isinstance(compression, str) or compression.lower() not in str_to_compression:
+        valid = ", ".join(sorted(map(repr, str_to_compression)))
+        raise ValueError(f"compression argument should be one of {valid}")
+    else:
+        compression = compression.lower()
+        comp = str_to_compression[compression]
+    if level is not None:
+        if compression != "lz4hc":
+            raise TypeError('level argument is only valid when using "lz4hc" compression')
+        level = int(level)
+        if level < 1 or level > 9:
+            raise ValueError(
+                f"level argument should be an integer between 1 and 9 (got {level}).  "
+                "1 is the fastest, 9 is the most compression (default is 9)."
+            )
+        comp += level
+    if nthreads is not None:
+        nthreads = max(0, int(nthreads))
+        key = frozenset([("compression", comp), ("nthreads", nthreads)])
+    else:
+        key = frozenset([("compression", comp)])
+    if key in _desc_map:
+        return _desc_map[key]
+    if nthreads is not None:
+        desc = get_nthreads_descriptor(nthreads, _cache=False)
+    else:
+        desc_obj = ffi.new("GrB_Descriptor*")
+        lib.GrB_Descriptor_new(desc_obj)
+        name = f"compression_{compression}{level or ''}"
+        if nthreads and nthreads > 0:
+            name += f"_nthreads{nthreads}"
+        desc = Descriptor(desc_obj[0], name)
+    check_status(
+        lib.GxB_Desc_set(
+            desc._carg,
+            lib.GxB_COMPRESSION,
+            ffi.cast("GrB_Desc_Value", comp),
+        ),
+        desc,
+    )
+    _desc_map[key] = desc
+    return desc

--- a/graphblas/_ss/descriptor.py
+++ b/graphblas/_ss/descriptor.py
@@ -27,7 +27,7 @@ def get_nthreads_descriptor(nthreads, _cache=True):
         desc,
     )
     if _cache:
-        _cache[key] = desc
+        _desc_map[key] = desc
     return desc
 
 
@@ -62,10 +62,11 @@ def get_compression_descriptor(compression="default", level=None, nthreads=None)
     else:
         desc_obj = ffi.new("GrB_Descriptor*")
         lib.GrB_Descriptor_new(desc_obj)
-        name = f"compression_{compression}{level or ''}"
-        if nthreads and nthreads > 0:
-            name += f"_nthreads{nthreads}"
-        desc = Descriptor(desc_obj[0], name)
+        desc = Descriptor(desc_obj[0], "")
+    name = f"compression_{compression}{level or ''}"
+    if nthreads and nthreads > 0:
+        name += f"_nthreads{nthreads}"
+    desc.name = name
     check_status(
         lib.GxB_Desc_set(
             desc._carg,

--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -3993,7 +3993,7 @@ class ss:
         return claim_buffer(ffi, blob_handle[0], blob_size_handle[0], np.dtype(np.uint8))
 
     @classmethod
-    def deserialize(cls, data, *, nthreads=None, name=None):
+    def deserialize(cls, data, dtype=None, *, unsafe=False, nthreads=None, name=None):
         """Deserialize a Matrix from bytes, buffer, or numpy array using GxB_Matrix_deserialize.
 
         The data should have been previously serialized with a compatible version of
@@ -4008,6 +4008,15 @@ class ss:
 
         Parameters
         ----------
+        dtype : DataType, optional
+            If given, this should specify the dtype of the object.  This is usually unnecessary.
+            If the dtype doesn't match what is in the serialized metadata, deserialize will fail.
+            You need to specify the dtype to _safely_ load user-defined types.
+        unsafe : bool, default False
+            Ignored for builtin types.  Automatic loading of user-defined types (if not given via
+            the `dtype=` argument) may require `eval`, which is often considered unsafe in Python
+            if you don't trust the data.  Hence, you must opt-in by specifying `unsafe=True`.
+            Automatically loading UDTs will probably only work for objects saved by this library.
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
@@ -4018,16 +4027,25 @@ class ss:
             data = np.frombuffer(data, np.uint8)
         data_obj = ffi.from_buffer("void*", data)
         # Get the dtype name first
-        cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
-        info = lib.GxB_deserialize_type_name(
-            cname,
-            data_obj,
-            data.nbytes,
-        )
-        if info != lib.GrB_SUCCESS:
-            raise _error_code_lookup[info]("Matrix deserialize failed to get the dtype name")
-        dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-        dtype = lookup_dtype(dtype_name)
+        if dtype is None:
+            cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
+            info = lib.GxB_deserialize_type_name(
+                cname,
+                data_obj,
+                data.nbytes,
+            )
+            if info != lib.GrB_SUCCESS:
+                raise _error_code_lookup[info]("Matrix deserialize failed to get the dtype name")
+            dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
+            try:
+                dtype = lookup_dtype(dtype_name)
+            except ValueError:
+                if not unsafe:
+                    raise
+                np_dtype = np.dtype(eval(dtype_name, np.__dict__))
+                dtype = lookup_dtype(np_dtype)
+        else:
+            dtype = lookup_dtype(dtype)
         if nthreads is not None:
             desc_obj = get_nthreads_descriptor(nthreads)._carg
         else:

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -1562,7 +1562,7 @@ class ss:
         return claim_buffer(ffi, blob_handle[0], blob_size_handle[0], np.dtype(np.uint8))
 
     @classmethod
-    def deserialize(cls, data, *, nthreads=None, name=None):
+    def deserialize(cls, data, dtype=None, *, unsafe=False, nthreads=None, name=None):
         """Deserialize a Vector from bytes, buffer, or numpy array using GxB_Vector_deserialize.
 
         The data should have been previously serialized with a compatible version of
@@ -1577,6 +1577,15 @@ class ss:
 
         Parameters
         ----------
+        dtype : DataType, optional
+            If given, this should specify the dtype of the object.  This is usually unnecessary.
+            If the dtype doesn't match what is in the serialized metadata, deserialize will fail.
+            You need to specify the dtype to _safely_ load user-defined types.
+        unsafe : bool, default False
+            Ignored for builtin types.  Automatic loading of user-defined types (if not given via
+            the `dtype=` argument) may require `eval`, which is often considered unsafe in Python
+            if you don't trust the data.  Hence, you must opt-in by specifying `unsafe=True`.
+            Automatically loading UDTs will probably only work for objects saved by this library.
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
@@ -1586,17 +1595,26 @@ class ss:
         else:
             data = np.frombuffer(data, np.uint8)
         data_obj = ffi.from_buffer("void*", data)
-        # Get the dtype name first
-        cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
-        info = lib.GxB_deserialize_type_name(
-            cname,
-            data_obj,
-            data.nbytes,
-        )
-        if info != lib.GrB_SUCCESS:
-            raise _error_code_lookup[info]("Vector deserialize failed to get the dtype name")
-        dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-        dtype = lookup_dtype(dtype_name)
+        if dtype is None:
+            # Get the dtype name first
+            cname = ffi_new(f"char[{lib.GxB_MAX_NAME_LEN}]")
+            info = lib.GxB_deserialize_type_name(
+                cname,
+                data_obj,
+                data.nbytes,
+            )
+            if info != lib.GrB_SUCCESS:
+                raise _error_code_lookup[info]("Vector deserialize failed to get the dtype name")
+            dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
+            try:
+                dtype = lookup_dtype(dtype_name)
+            except ValueError:
+                if not unsafe:
+                    raise
+                np_dtype = np.dtype(eval(dtype_name, np.__dict__))
+                dtype = lookup_dtype(np_dtype)
+        else:
+            dtype = lookup_dtype(dtype)
         if nthreads is not None:
             desc_obj = get_nthreads_descriptor(nthreads)._carg
         else:

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -1522,6 +1522,30 @@ class ss:
         )
 
     def serialize(self, compression="default", level=None, *, nthreads=None):
+        """Serialize a Vector to bytes (as numpy array) using SuiteSparse GxB_Vector_serialize.
+
+        Parameters
+        ----------
+        compression : {"default", "lz4", "lz4hc", "none", None}, optional
+            Whether and how to compress the data.
+            - "default": the default in SuiteSparse:GraphBLAS, which is currently LZ4
+            - "lz4": the default LZ4 compression
+            - "lz4hc": LZ4 compression that allows the compression level (1-9) to be set.
+              Low compression level (1) is faster, high (9) is more compact.  Default is 9.
+            - "none" or None: no compression
+        level : int [1-9], optional
+            The compression level, between 1 to 9, to use with "lz4hc" compression.
+            (1) is the fastest and largest, (9) is the slowest and most compressed.
+            Level 9 is the default when using "lz4hc" compression.
+        nthreads : int, optional
+            The maximum number of threads to use when serializing the Vector.
+            None, 0 or negative nthreads means to use the default number of threads.
+
+        For best performance, this function returns a numpy array with uint8 dtype.
+        Use `Vector.ss.deserialize(blob)` to create a Vector from the result of serialization·
+
+        This method is intended to support all serialization options from SuiteSparse:GraphBLAS.
+        """
         desc = get_compression_descriptor(compression, level=level, nthreads=nthreads)
         blob_handle = ffi_new("void**")
         blob_size_handle = ffi_new("GrB_Index*")
@@ -1535,11 +1559,28 @@ class ss:
             ),
             parent,
         )
-        # Should we return numpy array or bytes?
         return claim_buffer(ffi, blob_handle[0], blob_size_handle[0], np.dtype(np.uint8))
 
     @classmethod
     def deserialize(cls, data, *, nthreads=None, name=None):
+        """Deserialize a Vector from bytes, buffer, or numpy array using GxB_Vector_deserialize.
+
+        The data should have been previously serialized with a compatible version of
+        SuiteSparse:GraphBLAS.  For example, from the result of `data = vector.ss.serialize()`.
+
+        Examples
+        --------
+        >>> data = vector.serialize()
+        >>> new_vector = Vector.ss.deserialize(data)
+        >>> new_vector.isequal(vector)
+        True
+
+        Parameters
+        ----------
+        nthreads : int, optional
+            The maximum number of threads to use when deserializing.
+            None, 0 or negative nthreads means to use the default number of threads.
+        """
         if isinstance(data, np.ndarray):
             data = ints_to_numpy_buffer(data, np.uint8)
         else:
@@ -1557,12 +1598,12 @@ class ss:
         dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
         dtype = lookup_dtype(dtype_name)
         if nthreads is not None:
-            desc = get_nthreads_descriptor(nthreads)
+            desc_obj = get_nthreads_descriptor(nthreads)._carg
         else:
-            desc = NULL
+            desc_obj = NULL
         gb_obj = ffi_new("GrB_Vector*")
         check_status_carg(
-            lib.GxB_Vector_deserialize(gb_obj, dtype._carg, data_obj, data.nbytes, desc),
+            lib.GxB_Vector_deserialize(gb_obj, dtype._carg, data_obj, data.nbytes, desc_obj),
             "Vector",
             gb_obj[0],
         )

--- a/graphblas/dtypes.py
+++ b/graphblas/dtypes.py
@@ -120,7 +120,7 @@ def register_anonymous(dtype, name=None):
                     f"and the dtype may need to be specified when deserializing: {np_repr}"
                 )
             status = lib.GxB_Type_new(gb_obj, dtype.itemsize, np_repr, ffi.NULL)
-        else:
+        else:  # pragma: no cover
             status = lib.GrB_Type_new(gb_obj, dtype.itemsize)
         check_status_carg(status, "Type", gb_obj[0])
     # For now, let's use "opaque" unsigned bytes for the c type.

--- a/graphblas/dtypes.py
+++ b/graphblas/dtypes.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numba
 import numpy as np
 from numpy import find_common_type, promote_types
@@ -102,7 +104,24 @@ def register_anonymous(dtype, name=None):
         from .exceptions import check_status_carg
 
         gb_obj = ffi.new("GrB_Type*")
-        status = lib.GrB_Type_new(gb_obj, dtype.itemsize)
+        if hasattr(lib, "GxB_MAX_NAME_LEN"):
+            # SS, SuiteSparse-specific: naming dtypes
+            # We name this so that we can serialize and deserialize UDTs
+            # We don't yet have C definitions
+            np_repr = repr(dtype).encode()
+            if len(np_repr) > lib.GxB_MAX_NAME_LEN:
+                if name is not None:
+                    np_repr = name.encode()[: lib.GxB_MAX_NAME_LEN]
+                else:
+                    np_repr = np_repr[: lib.GxB_MAX_NAME_LEN]
+                warnings.warn(
+                    f"UDT repr is too large to serialize ({len(repr(dtype).encode())} > "
+                    f"{lib.GxB_MAX_NAME_LEN}).  It will use the following name, "
+                    f"and the dtype may need to be specified when deserializing: {np_repr}"
+                )
+            status = lib.GxB_Type_new(gb_obj, dtype.itemsize, np_repr, ffi.NULL)
+        else:
+            status = lib.GrB_Type_new(gb_obj, dtype.itemsize)
         check_status_carg(status, "Type", gb_obj[0])
     # For now, let's use "opaque" unsigned bytes for the c type.
     if name is None:

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3439,6 +3439,13 @@ def test_udt():
     with pytest.raises(ValueError, match="shape mismatch"):
         A[[0, 1], [1]] = [[(2, 3), (4, 5)]]
 
+    AA = Matrix.ss.deserialize(A.ss.serialize(), unsafe=True)
+    assert A.isequal(AA, check_dtype=True)
+    AA = Matrix.ss.deserialize(A.ss.serialize(), dtype=A.dtype)
+    assert A.isequal(AA, check_dtype=True)
+    with pytest.raises(ValueError):
+        Matrix.ss.deserialize(A.ss.serialize())
+
     np_dtype = np.dtype("(3,)uint16")
     udt = dtypes.register_anonymous(np_dtype, "has_subdtype")
     A = Matrix(udt, nrows=2, ncols=2)
@@ -3461,6 +3468,8 @@ def test_udt():
     expected = Matrix.from_values([0, 1], [1, 1], [[2, 3, 4], [5, 6, 7]], dtype=udt)
     assert A.isequal(expected)
     A[[0, 1], [1]] = [[[2, 3, 4]], [[5, 6, 7]]]
+    AA = Matrix.ss.deserialize(A.ss.serialize(), unsafe=True)
+    assert A.isequal(AA, check_dtype=True)
     with pytest.raises(ValueError, match="shape mismatch"):
         A[[0, 1], [1]] = [[[2, 3, 4], [5, 6, 7]]]
     with pytest.raises(ValueError, match="shape mismatch"):

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -14,6 +14,7 @@ from graphblas.exceptions import (
     DimensionMismatch,
     EmptyObject,
     IndexOutOfBound,
+    InvalidObject,
     InvalidValue,
     NotImplementedException,
     OutputNotEmpty,
@@ -3565,7 +3566,7 @@ def test_ss_serialize(A):
                 A.ss.serialize(compression, level, nthreads=nthreads)
             continue
         a = A.ss.serialize(compression, level, nthreads=nthreads)
-        C = Matrix.ss.deserialize(a)
+        C = Matrix.ss.deserialize(a, nthreads=nthreads)
         assert A.isequal(C, check_dtype=True)
     b = a.tobytes()
     C = Matrix.ss.deserialize(b)
@@ -3576,3 +3577,5 @@ def test_ss_serialize(A):
         A.ss.serialize("lz4hc", -1)
     with pytest.raises(ValueError, match="level argument"):
         A.ss.serialize("lz4hc", 0)
+    with pytest.raises(InvalidObject):
+        Matrix.ss.deserialize(a[:-5])

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -14,6 +14,7 @@ from graphblas.exceptions import (
     DimensionMismatch,
     EmptyObject,
     IndexOutOfBound,
+    InvalidObject,
     InvalidValue,
     OutputNotEmpty,
 )
@@ -2208,7 +2209,7 @@ def test_ss_serialize(v):
                 v.ss.serialize(compression, level, nthreads=nthreads)
             continue
         a = v.ss.serialize(compression, level, nthreads=nthreads)
-        w = Vector.ss.deserialize(a)
+        w = Vector.ss.deserialize(a, nthreads=nthreads)
         assert v.isequal(w, check_dtype=True)
     b = a.tobytes()
     w = Vector.ss.deserialize(b)
@@ -2219,3 +2220,5 @@ def test_ss_serialize(v):
         v.ss.serialize("lz4hc", -1)
     with pytest.raises(ValueError, match="level argument"):
         v.ss.serialize("lz4hc", 0)
+    with pytest.raises(InvalidObject):
+        Vector.ss.deserialize(a[:-5])

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2197,3 +2197,22 @@ def test_get(v):
     with pytest.raises(ValueError):
         # Not yet supported
         v.get([0, 1])
+
+
+def test_ss_serialize(v):
+    for compression, level, nthreads in itertools.product(
+        [None, "none", "default", "lz4", "lz4hc"], [None, 1, 5, 9], [None, -1, 1, 10]
+    ):
+        if level is not None and compression != "lz4hc":
+            with pytest.raises(TypeError, match="level argument"):
+                v.ss.serialize(compression, level, nthreads=nthreads)
+            continue
+        a = v.ss.serialize(compression, level, nthreads=nthreads)
+        w = Vector.ss.deserialize(a)
+        assert v.isequal(w, check_dtype=True)
+    with pytest.raises(ValueError, match="compression argument"):
+        v.ss.serialize("bad")
+    with pytest.raises(ValueError, match="level argument"):
+        v.ss.serialize("lz4hc", -1)
+    with pytest.raises(ValueError, match="level argument"):
+        v.ss.serialize("lz4hc", 0)

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2210,6 +2210,9 @@ def test_ss_serialize(v):
         a = v.ss.serialize(compression, level, nthreads=nthreads)
         w = Vector.ss.deserialize(a)
         assert v.isequal(w, check_dtype=True)
+    b = a.tobytes()
+    w = Vector.ss.deserialize(b)
+    assert v.isequal(w, check_dtype=True)
     with pytest.raises(ValueError, match="compression argument"):
         v.ss.serialize("bad")
     with pytest.raises(ValueError, match="level argument"):


### PR DESCRIPTION
Fixes #200.

The GxB version of these methods is nicer to work with.  This PR still needs docs and probably a little more cleanup and testing.

Is it okay if `x.ss.serialize()` returns a numpy array of uint8, or would bytes be better?  It's easy to do `val.tobytes()`, but this performs a data copy, so I prefer to return a numpy array.

`.ss.deserialize` accepts a numpy array or buffer.