### PR TITLE
Safely deserialize UDT dtypes

### DIFF
--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -11,7 +11,7 @@ import graphblas as gb
 
 from .. import ffi, lib, monoid
 from ..base import call, record_raw
-from ..dtypes import _INDEX, INT64, lookup_dtype
+from ..dtypes import _INDEX, INT64, _string_to_dtype, lookup_dtype
 from ..exceptions import _error_code_lookup, check_status, check_status_carg
 from ..scalar import Scalar, _as_scalar, _scalar_index
 from ..utils import (
@@ -4032,11 +4032,7 @@ class ss:
             if info != lib.GrB_SUCCESS:
                 raise _error_code_lookup[info]("Matrix deserialize failed to get the dtype name")
             dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-            try:
-                dtype = lookup_dtype(dtype_name)
-            except ValueError:
-                np_dtype = np.dtype(eval(dtype_name, np.__dict__))
-                dtype = lookup_dtype(np_dtype)
+            dtype = _string_to_dtype(dtype_name)
         else:
             dtype = lookup_dtype(dtype)
         if nthreads is not None:

--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -3993,7 +3993,7 @@ class ss:
         return claim_buffer(ffi, blob_handle[0], blob_size_handle[0], np.dtype(np.uint8))
 
     @classmethod
-    def deserialize(cls, data, dtype=None, *, unsafe=False, nthreads=None, name=None):
+    def deserialize(cls, data, dtype=None, *, nthreads=None, name=None):
         """Deserialize a Matrix from bytes, buffer, or numpy array using GxB_Matrix_deserialize.
 
         The data should have been previously serialized with a compatible version of
@@ -4011,12 +4011,7 @@ class ss:
         dtype : DataType, optional
             If given, this should specify the dtype of the object.  This is usually unnecessary.
             If the dtype doesn't match what is in the serialized metadata, deserialize will fail.
-            You need to specify the dtype to _safely_ load user-defined types.
-        unsafe : bool, default False
-            Ignored for builtin types.  Automatic loading of user-defined types (if not given via
-            the `dtype=` argument) may require `eval`, which is often considered unsafe in Python
-            if you don't trust the data.  Hence, you must opt-in by specifying `unsafe=True`.
-            Automatically loading UDTs will probably only work for objects saved by this library.
+            You may need to specify the dtype to load user-defined types.
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
@@ -4040,8 +4035,6 @@ class ss:
             try:
                 dtype = lookup_dtype(dtype_name)
             except ValueError:
-                if not unsafe:
-                    raise
                 np_dtype = np.dtype(eval(dtype_name, np.__dict__))
                 dtype = lookup_dtype(np_dtype)
         else:

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -9,7 +9,7 @@ import graphblas as gb
 
 from .. import ffi, lib, monoid
 from ..base import call
-from ..dtypes import _INDEX, INT64, UINT64, lookup_dtype
+from ..dtypes import _INDEX, INT64, UINT64, _string_to_dtype, lookup_dtype
 from ..exceptions import _error_code_lookup, check_status, check_status_carg
 from ..scalar import Scalar, _as_scalar
 from ..utils import _CArray, ints_to_numpy_buffer, libget, values_to_numpy_buffer, wrapdoc
@@ -1601,11 +1601,7 @@ class ss:
             if info != lib.GrB_SUCCESS:
                 raise _error_code_lookup[info]("Vector deserialize failed to get the dtype name")
             dtype_name = b"".join(itertools.takewhile(b"\x00".__ne__, cname)).decode()
-            try:
-                dtype = lookup_dtype(dtype_name)
-            except ValueError:
-                np_dtype = np.dtype(np.lib.format.safe_eval(dtype_name))
-                dtype = lookup_dtype(np_dtype)
+            dtype = _string_to_dtype(dtype_name)
         else:
             dtype = lookup_dtype(dtype)
         if nthreads is not None:

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -1562,7 +1562,7 @@ class ss:
         return claim_buffer(ffi, blob_handle[0], blob_size_handle[0], np.dtype(np.uint8))
 
     @classmethod
-    def deserialize(cls, data, dtype=None, *, unsafe=False, nthreads=None, name=None):
+    def deserialize(cls, data, dtype=None, *, nthreads=None, name=None):
         """Deserialize a Vector from bytes, buffer, or numpy array using GxB_Vector_deserialize.
 
         The data should have been previously serialized with a compatible version of
@@ -1580,12 +1580,7 @@ class ss:
         dtype : DataType, optional
             If given, this should specify the dtype of the object.  This is usually unnecessary.
             If the dtype doesn't match what is in the serialized metadata, deserialize will fail.
-            You need to specify the dtype to _safely_ load user-defined types.
-        unsafe : bool, default False
-            Ignored for builtin types.  Automatic loading of user-defined types (if not given via
-            the `dtype=` argument) may require `eval`, which is often considered unsafe in Python
-            if you don't trust the data.  Hence, you must opt-in by specifying `unsafe=True`.
-            Automatically loading UDTs will probably only work for objects saved by this library.
+            You may need to specify the dtype to load user-defined types.
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
@@ -1609,9 +1604,7 @@ class ss:
             try:
                 dtype = lookup_dtype(dtype_name)
             except ValueError:
-                if not unsafe:
-                    raise
-                np_dtype = np.dtype(eval(dtype_name, np.__dict__))
+                np_dtype = np.dtype(np.lib.format.safe_eval(dtype_name))
                 dtype = lookup_dtype(np_dtype)
         else:
             dtype = lookup_dtype(dtype)

--- a/graphblas/dtypes.py
+++ b/graphblas/dtypes.py
@@ -222,9 +222,6 @@ for dtype in _dtypes_to_register:
     val = _sample_values[dtype]
     _registry[val.dtype] = dtype
     _registry[val.dtype.name] = dtype
-# Upcast numpy float16 to float32
-_registry[np.dtype(np.float16)] = FP32
-_registry["float16"] = FP32
 
 # Add some common Python types as lookup keys
 _registry[bool] = BOOL

--- a/graphblas/tests/test_dtype.py
+++ b/graphblas/tests/test_dtype.py
@@ -1,5 +1,6 @@
 import itertools
 import pickle
+import string
 
 import numpy as np
 import pytest
@@ -211,3 +212,22 @@ def test_default_names():
 def test_record_dtype_from_dict():
     dtype = dtypes.lookup_dtype({"x": int, "y": float})
     assert dtype.name == "{'x': INT64, 'y': FP64}"
+
+
+def test_dtype_to_from_string():
+    types = [dtypes.BOOL, dtypes.FP64]
+    for c in string.ascii_letters:
+        try:
+            dtype = np.dtype(c)
+            types.append(dtype)
+        except Exception:
+            pass
+    for dtype in types:
+        s = dtypes._dtype_to_string(dtype)
+        try:
+            dtype2 = dtypes._string_to_dtype(s)
+        except Exception:
+            with pytest.raises(Exception):
+                lookup_dtype(dtype)
+        else:
+            assert dtype == dtype2

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3439,12 +3439,10 @@ def test_udt():
     with pytest.raises(ValueError, match="shape mismatch"):
         A[[0, 1], [1]] = [[(2, 3), (4, 5)]]
 
-    AA = Matrix.ss.deserialize(A.ss.serialize(), unsafe=True)
+    AA = Matrix.ss.deserialize(A.ss.serialize())
     assert A.isequal(AA, check_dtype=True)
     AA = Matrix.ss.deserialize(A.ss.serialize(), dtype=A.dtype)
     assert A.isequal(AA, check_dtype=True)
-    with pytest.raises(ValueError):
-        Matrix.ss.deserialize(A.ss.serialize())
 
     np_dtype = np.dtype("(3,)uint16")
     udt = dtypes.register_anonymous(np_dtype, "has_subdtype")
@@ -3468,7 +3466,7 @@ def test_udt():
     expected = Matrix.from_values([0, 1], [1, 1], [[2, 3, 4], [5, 6, 7]], dtype=udt)
     assert A.isequal(expected)
     A[[0, 1], [1]] = [[[2, 3, 4]], [[5, 6, 7]]]
-    AA = Matrix.ss.deserialize(A.ss.serialize(), unsafe=True)
+    AA = Matrix.ss.deserialize(A.ss.serialize())
     assert A.isequal(AA, check_dtype=True)
     with pytest.raises(ValueError, match="shape mismatch"):
         A[[0, 1], [1]] = [[[2, 3, 4], [5, 6, 7]]]

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1946,12 +1946,10 @@ def test_udt():
     v.clear()
     v[[0, 1]] = [(2, 3), (4, 5)]
     expected = Vector.from_values([0, 1], [(2, 3), (4, 5)], dtype=udt, size=v.size)
-    vv = Vector.ss.deserialize(v.ss.serialize(), unsafe=True)
+    vv = Vector.ss.deserialize(v.ss.serialize())
     assert v.isequal(vv, check_dtype=True)
     vv = Vector.ss.deserialize(v.ss.serialize(), dtype=v.dtype)
     assert v.isequal(vv, check_dtype=True)
-    with pytest.raises(ValueError):
-        Vector.ss.deserialize(v.ss.serialize())
 
     # arrays as dtypes!
     np_dtype = np.dtype("(3,)uint16")
@@ -2001,7 +1999,7 @@ def test_udt():
     v[[0, 1]] = [[2, 3, 4], [5, 6, 7]]
     expected = Vector.from_values([0, 1], [[2, 3, 4], [5, 6, 7]], dtype=udt2, size=v.size)
     assert v.isequal(expected)
-    vv = Vector.ss.deserialize(v.ss.serialize(), unsafe=True)
+    vv = Vector.ss.deserialize(v.ss.serialize())
     assert v.isequal(vv, check_dtype=True)
 
     long_dtype = np.dtype([("x", np.bool_), ("y" * 1000, np.float64)], align=True)
@@ -2014,7 +2012,7 @@ def test_udt():
     assert v.isequal(vv, check_dtype=True)
     with pytest.raises(Exception):
         # The size of the UDT name is limited
-        Vector.ss.deserialize(v.ss.serialize(), unsafe=True)
+        Vector.ss.deserialize(v.ss.serialize())
     # May be able to look up non-anonymous dtypes by name if their names are too long
     named_long_dtype = np.dtype([("x", np.bool_), ("y" * 1000, np.float64)], align=False)
     with pytest.warns(UserWarning, match="too large"):


### PR DESCRIPTION
It's surprisingly annoying to convert a numpy dtype to and from a string, but this seems to do the trick and let's us do it safely without `eval`.