### PR TITLE
[EXPERIMENTAL] Add "onchange" hook

### DIFF
--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -442,6 +442,8 @@ class ss:
         vector = self._parent._expect_type(
             vector, gb.Vector, within="ss.build_diag", argname="vector"
         )
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         call("GxB_Matrix_diag", [self._parent, vector, _as_scalar(k, INT64, is_cscalar=True), None])
 
     def split(self, chunks, *, name=None):
@@ -544,6 +546,8 @@ class ss:
         graphblas.ss.concat
         """
         tiles, m, n, is_matrix = _concat_mn(tiles, is_matrix=True)
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         self._concat(tiles, m, n)
 
     def build_scalar(self, rows, columns, value):
@@ -564,6 +568,8 @@ class ss:
                 f"`rows` and `columns` lengths must match: {rows.size}, {columns.size}"
             )
         scalar = _as_scalar(value, self._parent.dtype, is_cscalar=False)  # pragma: is_grbscalar
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         call(
             "GxB_Matrix_build_Scalar",
             [
@@ -897,8 +903,12 @@ class ss:
                 format = f"{self.format[:-1]}r"
             elif format == "columnwise":
                 format = f"{self.format[:-1]}c"
-        if give_ownership or format == "coo":
+        if format == "coo":
             parent = self._parent
+        elif give_ownership:
+            parent = self._parent
+            if parent._hooks is not None and "onchange" in parent._hooks:
+                parent._hooks["onchange"](self)
         else:
             parent = self._parent.dup(name=f"M_{method}")
         dtype = parent.dtype.np_type
@@ -1388,6 +1398,8 @@ class ss:
 
         See `Matrix.ss.import_csr` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_csr(
             indptr=indptr,
             values=values,
@@ -1561,6 +1573,8 @@ class ss:
 
         See `Matrix.ss.import_csc` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_csc(
             indptr=indptr,
             values=values,
@@ -1744,6 +1758,8 @@ class ss:
 
         See `Matrix.ss.import_hypercsr` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_hypercsr(
             rows=rows,
             indptr=indptr,
@@ -1938,6 +1954,8 @@ class ss:
 
         See `Matrix.ss.import_hypercsc` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_hypercsc(
             cols=cols,
             indptr=indptr,
@@ -2126,6 +2144,8 @@ class ss:
 
         See `Matrix.ss.import_bitmapr` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_bitmapr(
             bitmap=bitmap,
             values=values,
@@ -2302,6 +2322,8 @@ class ss:
 
         See `Matrix.ss.import_bitmapc` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_bitmapc(
             bitmap=bitmap,
             values=values,
@@ -2467,6 +2489,8 @@ class ss:
 
         See `Matrix.ss.import_fullr` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_fullr(
             values=values,
             is_iso=is_iso,
@@ -2614,6 +2638,8 @@ class ss:
 
         See `Matrix.ss.import_fullc` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_fullc(
             values=values,
             is_iso=is_iso,
@@ -2765,6 +2791,8 @@ class ss:
 
         See `Matrix.ss.import_coo` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_coo(
             nrows=self._parent._nrows,
             ncols=self._parent._ncols,
@@ -2943,6 +2971,8 @@ class ss:
 
         See `Matrix.ss.import_coor` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_coor(
             rows=rows,
             cols=cols,
@@ -3096,6 +3126,8 @@ class ss:
 
         See `Matrix.ss.import_cooc` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_cooc(
             ncols=self._parent._ncols,
             rows=rows,
@@ -3284,6 +3316,8 @@ class ss:
 
         See `Matrix.ss.import_any` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_any(
             values=values,
             is_iso=is_iso,

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -169,6 +169,8 @@ class ss:
             # Transpose descriptor doesn't do anything, so use the parent
             k = -k
             matrix = matrix._matrix
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         call("GxB_Vector_diag", [self._parent, matrix, _as_scalar(k, INT64, is_cscalar=True), None])
 
     def split(self, chunks, *, name=None):
@@ -253,6 +255,8 @@ class ss:
         graphblas.ss.concat
         """
         tiles, m, n, is_matrix = _concat_mn(tiles, is_matrix=False)
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         self._concat(tiles, m)
 
     def build_scalar(self, indices, value):
@@ -268,6 +272,8 @@ class ss:
         """
         indices = ints_to_numpy_buffer(indices, np.uint64, name="indices")
         scalar = _as_scalar(value, self._parent.dtype, is_cscalar=False)  # pragma: is_grbscalar
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         call(
             "GxB_Vector_build_Scalar",
             [
@@ -464,6 +470,8 @@ class ss:
     def _export(self, format=None, *, sort=False, give_ownership=False, raw=False, method):
         if give_ownership:
             parent = self._parent
+            if parent._hooks is not None and "onchange" in parent._hooks:
+                parent._hooks["onchange"](self)
         else:
             parent = self._parent.dup(name=f"v_{method}")
         dtype = parent.dtype.np_type
@@ -680,6 +688,8 @@ class ss:
 
         See `Vector.ss.import_any` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_any(
             values=values,
             is_iso=is_iso,
@@ -860,6 +870,8 @@ class ss:
 
         See `Vector.ss.import_sparse` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_sparse(
             indices=indices,
             values=values,
@@ -1027,6 +1039,8 @@ class ss:
 
         See `Vector.ss.import_bitmap` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_bitmap(
             bitmap=bitmap,
             values=values,
@@ -1188,6 +1202,8 @@ class ss:
 
         See `Vector.ss.import_full` documentation for more details.
         """
+        if self._parent._hooks is not None and "onchange" in self._parent._hooks:
+            self._parent._hooks["onchange"](self)
         return self._import_full(
             values=values,
             is_iso=is_iso,

--- a/graphblas/expr.py
+++ b/graphblas/expr.py
@@ -406,6 +406,8 @@ class Updater:
 
     def _setitem(self, resolved_indexes, obj, *, is_submask):
         # Occurs when user calls C(params)[index] = expr
+        if self.parent._hooks is not None and "onchange" in self.parent._hooks:
+            self.parent._hooks["onchange"](self)
         if resolved_indexes.is_single_element and not self.kwargs:
             # Fast path using assignElement
             self.parent._assign_element(resolved_indexes, obj)
@@ -427,6 +429,8 @@ class Updater:
         if self.parent._is_scalar:
             raise TypeError("Indexing not supported for Scalars")
         resolved_indexes = IndexerResolver(self.parent, keys)
+        if self.parent._hooks is not None and "onchange" in self.parent._hooks:
+            self.parent._hooks["onchange"](self)
         if resolved_indexes.is_single_element:
             self.parent._delete_element(resolved_indexes)
         else:

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -319,6 +319,7 @@ def test_expr_is_like_scalar(s):
         "_expr_name",
         "_expr_name_html",
         "_from_obj",
+        "_hooks",
         "_name_counter",
         "_update",
         "clear",
@@ -351,6 +352,7 @@ def test_index_expr_is_like_scalar(s):
         "_expr_name",
         "_expr_name_html",
         "_from_obj",
+        "_hooks",
         "_name_counter",
         "_update",
         "clear",
@@ -458,3 +460,28 @@ def test_get(s):
     s.clear()
     assert compute(s.get()) is None
     assert s.get("mittens") == "mittens"
+
+
+def test_hooks(s):
+    t = s.dup()
+
+    class OnChangeException(Exception):
+        pass
+
+    def onchange(x, **kwargs):
+        raise OnChangeException()
+
+    t._hooks = {"onchange": onchange}
+    with pytest.raises(OnChangeException):
+        t.clear()
+    with pytest.raises(OnChangeException):
+        t.value = 7
+    v = Vector.from_values([1, 2], [3, 4])
+    with pytest.raises(OnChangeException):
+        t << v[1]
+    with pytest.raises(OnChangeException):
+        t << v.reduce()
+    with pytest.raises(OnChangeException):
+        t << v.reduce(gb.agg.count)
+    with pytest.raises(OnChangeException):
+        t << s


### PR DESCRIPTION
This is a PoC to see how invasive it is to add "onchange" hooks.

There _may_ be two uses for this from `graphblas-algorithms`:
1. Automatically invalidate the cache when the graph is modified.
    - This allows us to more safely expose the adjacency matrix `A` to the user.
2. Make cached values read-only.

Overall, I'd say this isn't very invasive all things considered. The number of places hooks are in each file is:
- expr.py: **2**
- base.py: **4**
- scalar.py: **2**
- vector.py: **3**
- matrix.py: **3**
- _ss/matrix.py and _ss/vector.py: a bunch due to pack methods

This hook system is pretty simple for now.  It only has one hook, `"onchange"`, and it only passes the object that would be changed to the function.  Other hooks and arguments to pass to the callbacks are possible (hence our use of `**kwargs` in the callback for future compatibility).  This also doesn't try to manage having multiple callbacks, which is fine for our current use cases where the objects with hooks will be managed by `graphblas-algorithms`.

We may want to add a simple API to manage hooks such as `_add_hook`, `_has_hook`, `_call_hook`, etc. to make it easier to evolve.

We can let this stew for a bit.