### PR TITLE
Use `_repr_html_` for rich display of recorder.

### DIFF
--- a/graphblas/dtypes.py
+++ b/graphblas/dtypes.py
@@ -257,7 +257,7 @@ def lookup_dtype(key, value=None):
         return lookup_dtype(key.literal_type)  # For numba dtype inference
     except Exception:
         pass
-    raise ValueError(f"Unknown dtype: {key}", type(key))
+    raise ValueError(f"Unknown dtype: {key} of type {type(key)}")
 
 
 def unify(type1, type2, *, is_left_scalar=False, is_right_scalar=False):

--- a/graphblas/recorder.py
+++ b/graphblas/recorder.py
@@ -103,9 +103,7 @@ class Recorder:
     def is_recording(self):
         return self._token is not None and _recorder.get(base._prev_recorder) is self
 
-    def _repr_markdown_(self):
-        # Syntax highlighting from github-flavored markdown looks better than
-        # using IPython.display.Code or pygments
+    def _repr_base_(self):
         status = (
             '<div style="'
             "height: 12px; "
@@ -118,11 +116,11 @@ class Recorder:
         )
         if self.is_recording:
             # red circle for recording
-            status = status % ("background-color: red; " "border-radius: 50%;")
+            status = status % ("background-color: red; border-radius: 50%;")
         else:
             # two vertical bars for paused
-            status = status % ("border-right: 5px solid gray; " "border-left: 5px solid gray;")
-        lines = [
+            status = status % ("border-right: 5px solid gray; border-left: 5px solid gray;")
+        head = [
             "<div>",
             f"{CSS_STYLE}",
             '<details open class="gb-arg-details">',
@@ -135,27 +133,48 @@ class Recorder:
             "</table>",
             "</summary>",
             '<blockquote class="gb-expr-blockquote" style="margin-left: -8px;">',
-            "",
-            "```C",
-            "  " + "\n  ".join(self.data),
-            "```",
-            "</blockquote>",
-            "</details>",
-            "</div>",
         ]
-        return "\n".join(lines)
+        tail = "\n</blockquote>\n</details>\n</div>"
+        return "\n".join(head), tail
+
+    def _repr_html_(self):
+        try:
+            from IPython.display import Code
+        except ImportError:  # pragma: no cover
+            raise NotImplementedError()
+        lines = self._get_repr_lines()
+        code = Code("\n".join(lines), language="C")
+        head, tail = self._repr_base_()
+        return head + code._repr_html_() + tail
+
+    def _repr_markdown_(self):
+        # Syntax highlighting from github-flavored markdown looks better than
+        # using IPython.display.Code or pygments
+        lines = self._get_repr_lines()
+        code = "\n\n```C\n" + "\n".join(lines) + "\n```"
+        head, tail = self._repr_base_()
+        return head + code + tail
+
+    def _get_repr_lines(self, indent=""):
+        lines = []
+        if self.max_rows is not None and len(self.data) > self.max_rows:
+            lines.extend(f"{indent}{line}" for line in self.data[: self.max_rows // 2])
+            lines.append("")
+            lines.append(
+                f"{indent}// {len(self.data) - self.max_rows} rows not shown; "
+                # f"{indent}// {len(self.data) - self.max_rows} rows not shown; "
+                "set `recorder.max_rows` attribute to show more (or less)"
+            )
+            lines.append("")
+            lines.extend(f"{indent}{line}" for line in self.data[-((self.max_rows + 1) // 2) :])
+        else:
+            lines.extend(f"{indent}{line}" for line in self.data)
+        return lines
 
     def __repr__(self):
         lines = [f'gb.Recorder ({"" if self.is_recording else "not "}recording)']
         lines.append("-" * len(lines[0]))
-        if self.max_rows is not None and len(self.data) > self.max_rows:
-            lines.extend(f"  {line}" for line in self.data[: self.max_rows // 2])
-            lines.append("")
-            lines.append(f"  ... ({len(self.data) - self.max_rows} rows not shown)")
-            lines.append("")
-            lines.extend(f"  {line}" for line in self.data[-((self.max_rows + 1) // 2) :])
-        else:
-            lines.extend(f"  {line}" for line in self.data)
+        lines.extend(self._get_repr_lines(indent="  "))
         return "\n".join(lines)
 
 

--- a/graphblas/tests/test_recorder.py
+++ b/graphblas/tests/test_recorder.py
@@ -121,7 +121,7 @@ def test_record_repr(switch):
             "  GrB_Matrix_extractElement_INT64(&c3, A, 0, 0);\n"
             "  GrB_Matrix_extractElement_INT64(&c4, A, 0, 0);\n"
             "\n"
-            "  ... (10 rows not shown)\n"
+            "  // 30 rows not shown; set `recorder.max_rows` attribute to show more (or less)\n"
             "\n"
             "  GrB_Matrix_extractElement_INT64(&c15, A, 0, 0);\n"
             "  GrB_Matrix_extractElement_INT64(&c16, A, 0, 0);\n"
@@ -139,7 +139,7 @@ def test_record_repr(switch):
             "  GrB_Matrix_extractElement_Scalar(c1, A, 0, 0);\n"
             "  GrB_Scalar_new(&c2, GrB_INT64);\n"
             "\n"
-            "  ... (30 rows not shown)\n"
+            "  // 30 rows not shown; set `recorder.max_rows` attribute to show more (or less)\n"
             "\n"
             "  GrB_Matrix_extractElement_Scalar(c17, A, 0, 0);\n"
             "  GrB_Scalar_new(&c18, GrB_INT64);\n"
@@ -156,11 +156,9 @@ def test_record_repr_markdown(switch):
     rec.start()
     A[0, 0].new(name="c")
     if switch:
-        text = "  GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
+        text = "GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
     else:
-        text = (
-            "  GrB_Scalar_new(&c, GrB_INT64);\n" "  GrB_Matrix_extractElement_Scalar(c, A, 0, 0);\n"
-        )
+        text = "GrB_Scalar_new(&c, GrB_INT64);\nGrB_Matrix_extractElement_Scalar(c, A, 0, 0);\n"
     assert rec._repr_markdown_() == (
         "<div>\n"
         f"{CSS_STYLE}\n"
@@ -185,11 +183,9 @@ def test_record_repr_markdown(switch):
     )
     rec.stop()
     if switch:
-        text = "  GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
+        text = "GrB_Matrix_extractElement_INT64(&c, A, 0, 0);\n"
     else:
-        text = (
-            "  GrB_Scalar_new(&c, GrB_INT64);\n" "  GrB_Matrix_extractElement_Scalar(c, A, 0, 0);\n"
-        )
+        text = "GrB_Scalar_new(&c, GrB_INT64);\nGrB_Matrix_extractElement_Scalar(c, A, 0, 0);\n"
     assert rec._repr_markdown_() == (
         "<div>\n"
         f"{CSS_STYLE}\n"
@@ -212,6 +208,20 @@ def test_record_repr_markdown(switch):
         "</details>\n"
         "</div>"
     )
+
+
+def test_record_repr_html(switch):
+    A = gb.Matrix(int, 3, 3, name="A")
+    rec = gb.Recorder()
+    rec.start()
+    A[0, 0].new(name="c")
+    try:
+        import IPython  # noqa
+    except ImportError:
+        with pytest.raises(NotImplementedError):
+            rec._repr_html_()
+    else:  # pragma: no cover
+        assert isinstance(rec._repr_html_(), str)
 
 
 def test_record_failed_call():


### PR DESCRIPTION
I think code highlighting looks better in markdown, but it's better to be able to export notebooks as functional html.