### PR TITLE
Add .readthedocs.yml config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+conda:
+  environment: docs/env.yml

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -1,0 +1,15 @@
+name: python-graphblas-docs
+channels:
+    - conda-forge
+dependencies:
+    - python=3.8
+    - graphblas
+    - matplotlib
+    - networkx
+    - pandas
+    - scipy
+    - pip
+    - pip:
+        - nbsphinx
+        - sphinx_panels
+        - pydata_sphinx_theme

--- a/docs/user_guide/operators.rst
+++ b/docs/user_guide/operators.rst
@@ -184,7 +184,7 @@ Example usage with a thunk parameter:
 
 Defined IndexUnary operators are:
 
-    **index** -- return the vector index
+  - **index** -- return the vector index
   - **rowindex** -- return the matrix row index
   - **colindex** -- return the matrix column index
   - **diagindex** -- return the matrix diagonal index (i.e. column - row)


### PR DESCRIPTION
Docs are not building without a config file to specify additional pip-installed items needed by sphinx.