### PR TITLE
Matrix reshape

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -66,7 +66,7 @@ jobs:
           if [[ ${{ matrix.cfg.sourcetype }} == "wheel" ]]; then
               pip install suitesparse-graphblas
           else
-              conda install -c conda-forge "graphblas>=7.1.0"
+              conda install -c conda-forge "graphblas>=7.2.0"
           fi
           if [[ ${{ matrix.cfg.sourcetype }} == "source" ]]; then
               pip install --no-binary=all suitesparse-graphblas

--- a/graphblas/_ss/descriptor.py
+++ b/graphblas/_ss/descriptor.py
@@ -7,6 +7,7 @@ str_to_compression = {
     "default": lib.GxB_COMPRESSION_DEFAULT,
     "lz4": lib.GxB_COMPRESSION_LZ4,
     "lz4hc": lib.GxB_COMPRESSION_LZ4HC,
+    "zstd": lib.GxB_COMPRESSION_ZSTD,
 }
 
 
@@ -41,13 +42,15 @@ def get_compression_descriptor(compression="default", level=None, nthreads=None)
         compression = compression.lower()
         comp = str_to_compression[compression]
     if level is not None:
-        if compression != "lz4hc":
+        if compression not in {"lz4hc", "zstd"}:
             raise TypeError('level argument is only valid when using "lz4hc" compression')
         level = int(level)
-        if level < 1 or level > 9:
+        upper = 9 if compression == "lz4hc" else 19
+        default = 9 if compression == "lz4hc" else 1
+        if level < 1 or level > upper:
             raise ValueError(
-                f"level argument should be an integer between 1 and 9 (got {level}).  "
-                "1 is the fastest, 9 is the most compression (default is 9)."
+                f"level argument should be an integer between 1 and {upper} (got {level}).  "
+                f"1 is the fastest, {upper} is the most compression (default is {default})."
             )
         comp += level
     if nthreads is not None:

--- a/graphblas/_ss/matrix.py
+++ b/graphblas/_ss/matrix.py
@@ -4073,16 +4073,18 @@ class ss:
 
         Parameters
         ----------
-        compression : {"default", "lz4", "lz4hc", "none", None}, optional
+        compression : {"default", "lz4", "lz4hc", "zstd", "none", None}, optional
             Whether and how to compress the data.
-            - "default": the default in SuiteSparse:GraphBLAS, which is currently LZ4
+            - "default": the default in SuiteSparse:GraphBLAS, which is currently ZSTD
             - "lz4": the default LZ4 compression
             - "lz4hc": LZ4 compression that allows the compression level (1-9) to be set.
               Low compression level (1) is faster, high (9) is more compact.  Default is 9.
+            - "zstd": ZSTD compression, which allows compression level (1-19) to be set.
+              Low compression level (1) is faster, high (19) is more compact.  Default is 19.
             - "none" or None: no compression
         level : int [1-9], optional
-            The compression level, between 1 to 9, to use with "lz4hc" compression.
-            (1) is the fastest and largest, (9) is the slowest and most compressed.
+            The compression level, between 1 to 9, to use with "lz4hc" and "zstd" compression.
+            Level 1 is the fastest and largest, and is the default for "zstd" compression.
             Level 9 is the default when using "lz4hc" compression.
         nthreads : int, optional
             The maximum number of threads to use when serializing the Matrix.

--- a/graphblas/_ss/utils.py
+++ b/graphblas/_ss/utils.py
@@ -2,7 +2,7 @@ def get_order(order):
     val = order.lower()
     if val in {"c", "row", "rows", "rowwise"}:
         return "rowwise"
-    elif val in {"f", "col", "cols", "column", "columns", "columnwise"}:
+    elif val in {"f", "col", "cols", "column", "columns", "colwise", "columnwise"}:
         return "columnwise"
     else:
         raise ValueError(

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -1336,7 +1336,7 @@ class ss:
             "rowwise" means to fill the Matrix in row-major (C-style) order.
             Aliases of "rowwise" also accepted: "row", "rows", "C".
             "columnwise" means to fill the Matrix in column-major (F-style) order.
-            Aliases of "rowwise" also accepted: "col", "cols", "column", "columns", "F".
+            Aliases of "columnwise" also accepted: "col", "cols", "column", "columns", "F".
             The default is "rowwise".
         name : str, optional
             Name of the new Matrix.

--- a/graphblas/_ss/vector.py
+++ b/graphblas/_ss/vector.py
@@ -1580,16 +1580,18 @@ class ss:
 
         Parameters
         ----------
-        compression : {"default", "lz4", "lz4hc", "none", None}, optional
+        compression : {"default", "lz4", "lz4hc", "zstd", "none", None}, optional
             Whether and how to compress the data.
-            - "default": the default in SuiteSparse:GraphBLAS, which is currently LZ4
+            - "default": the default in SuiteSparse:GraphBLAS, which is currently ZSTD
             - "lz4": the default LZ4 compression
             - "lz4hc": LZ4 compression that allows the compression level (1-9) to be set.
               Low compression level (1) is faster, high (9) is more compact.  Default is 9.
+            - "zstd": ZSTD compression, which allows compression level (1-19) to be set.
+              Low compression level (1) is faster, high (19) is more compact.  Default is 19.
             - "none" or None: no compression
         level : int [1-9], optional
-            The compression level, between 1 to 9, to use with "lz4hc" compression.
-            (1) is the fastest and largest, (9) is the slowest and most compressed.
+            The compression level, between 1 to 9, to use with "lz4hc" and "zstd" compression.
+            Level 1 is the fastest and largest, and is the default for "zstd" compression.
             Level 9 is the default when using "lz4hc" compression.
         nthreads : int, optional
             The maximum number of threads to use when serializing the Vector.

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3604,9 +3604,9 @@ def test_bool_as_mask(A):
 
 def test_ss_serialize(A):
     for compression, level, nthreads in itertools.product(
-        [None, "none", "default", "lz4", "lz4hc"], [None, 1, 5, 9], [None, -1, 1, 10]
+        [None, "none", "default", "lz4", "lz4hc", "zstd"], [None, 1, 5, 9], [None, -1, 1, 10]
     ):
-        if level is not None and compression != "lz4hc":
+        if level is not None and compression not in {"lz4hc", "zstd"}:
             with pytest.raises(TypeError, match="level argument"):
                 A.ss.serialize(compression, level, nthreads=nthreads)
             continue
@@ -3622,6 +3622,8 @@ def test_ss_serialize(A):
         A.ss.serialize("lz4hc", -1)
     with pytest.raises(ValueError, match="level argument"):
         A.ss.serialize("lz4hc", 0)
+    with pytest.raises(ValueError, match="level argument"):
+        A.ss.serialize("zstd", 0)
     with pytest.raises(InvalidObject):
         Matrix.ss.deserialize(a[:-5])
 

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -2857,6 +2857,38 @@ def test_flatten(A):
         v.ss.reshape(A.shape + (1,))
 
 
+def test_ss_reshape(A):
+    A.resize(8, 8)
+    r, c, v = A.to_values()
+    idx = c + 8 * r
+    expected = Matrix.from_values(idx // 16, idx % 16, v, nrows=4, ncols=16)
+    rv = A.ss.reshape(4, 16)
+    assert rv.isequal(expected)
+    rv = A.ss.reshape(4, -1, order="row")
+    assert rv.isequal(expected)
+    rv = A.ss.reshape((4, 16))
+    assert rv.isequal(expected)
+    rv = A.ss.reshape((-1, 16))
+    assert rv.isequal(expected)
+    with pytest.raises(ValueError):
+        A.ss.reshape(5, 5)
+    with pytest.raises(ValueError):
+        A.ss.reshape(4)
+    with pytest.raises(ValueError):
+        A.ss.reshape((4,))
+    with pytest.raises(ValueError):
+        A.ss.reshape((4, 5))
+    with pytest.raises(ValueError):
+        A.ss.reshape((4, 4, 4))
+    with pytest.raises(ValueError):
+        A.ss.reshape(4, 16, order="bad_order")
+
+    idx = r + 8 * c
+    expected = Matrix.from_values(idx % 4, idx // 4, v, nrows=4, ncols=16)
+    rv = A.ss.reshape(4, 16, order="col")
+    assert rv.isequal(expected)
+
+
 def test_autocompute_argument_messages(A, v):
     with pytest.raises(TypeError, match="autocompute"):
         A.ewise_mult(A & A)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -2870,6 +2870,8 @@ def test_ss_reshape(A):
     assert rv.isequal(expected)
     rv = A.ss.reshape((-1, 16))
     assert rv.isequal(expected)
+    assert rv.ss.reshape(8, 8, inplace=True) is None
+    assert rv.isequal(A)
     with pytest.raises(ValueError):
         A.ss.reshape(5, 5)
     with pytest.raises(ValueError):

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2236,9 +2236,9 @@ def test_get(v):
 
 def test_ss_serialize(v):
     for compression, level, nthreads in itertools.product(
-        [None, "none", "default", "lz4", "lz4hc"], [None, 1, 5, 9], [None, -1, 1, 10]
+        [None, "none", "default", "lz4", "lz4hc", "zstd"], [None, 1, 5, 9], [None, -1, 1, 10]
     ):
-        if level is not None and compression != "lz4hc":
+        if level is not None and compression not in {"lz4hc", "zstd"}:
             with pytest.raises(TypeError, match="level argument"):
                 v.ss.serialize(compression, level, nthreads=nthreads)
             continue
@@ -2254,6 +2254,8 @@ def test_ss_serialize(v):
         v.ss.serialize("lz4hc", -1)
     with pytest.raises(ValueError, match="level argument"):
         v.ss.serialize("lz4hc", 0)
+    with pytest.raises(ValueError, match="level argument"):
+        v.ss.serialize("zstd", 0)
     with pytest.raises(InvalidObject):
         Vector.ss.deserialize(a[:-5])
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/python-graphblas/python-graphblas",
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=["suitesparse-graphblas >=7.1.0.0, <7.2", "numba", "donfig", "pyyaml"],
+    install_requires=["suitesparse-graphblas >=7.2.0.0, <7.3", "numba", "donfig", "pyyaml"],
     extras_require=extras_require,
     include_package_data=True,
     license="Apache License 2.0",


### PR DESCRIPTION
Add `matrix.ss.reshape` and update to SS:GB 7.2.0

This uses `GxB_Matrix_reshapeDup`. There is also `GxB_Matrix_reshape` that reshape inplace (and is faster) that we may want to expose too.  Not sure how though--`inplace=True`?  Also note that this method returns a new matrix, not an expression.

Also add "zstd" serialization option.