### PR TITLE
Update to SuiteSparse:GraphBLAS 7.3.0

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -66,7 +66,7 @@ jobs:
           if [[ ${{ matrix.cfg.sourcetype }} == "wheel" ]]; then
               pip install suitesparse-graphblas
           else
-              conda install -c conda-forge "graphblas>=7.2.0"
+              conda install -c conda-forge "graphblas>=7.3.0"
           fi
           if [[ ${{ matrix.cfg.sourcetype }} == "source" ]]; then
               pip install --no-binary=all suitesparse-graphblas

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/python-graphblas/python-graphblas",
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=["suitesparse-graphblas >=7.2.0.0, <7.3", "numba", "donfig", "pyyaml"],
+    install_requires=["suitesparse-graphblas >=7.2.0.0, <7.4", "numba", "donfig", "pyyaml"],
     extras_require=extras_require,
     include_package_data=True,
     license="Apache License 2.0",


### PR DESCRIPTION
`python-graphblas` is still compatible with 7.2.0, so it was kept as a min version.