### PR TITLE
Be more forgiving when assigning UDT scalar to everything

### DIFF
--- a/graphblas/core/base.py
+++ b/graphblas/core/base.py
@@ -394,8 +394,9 @@ class BaseType:
                     if type(expr) is Scalar:
                         scalar = expr
                     else:
+                        dtype = self.dtype if self.dtype._is_udt else None
                         try:
-                            scalar = Scalar.from_value(expr, is_cscalar=None, name="")
+                            scalar = Scalar.from_value(expr, dtype, is_cscalar=None, name="")
                         except TypeError:
                             raise TypeError(
                                 "Assignment value must be a valid expression type, not "

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3430,7 +3430,7 @@ def test_udt():
         [0, 0], [0, 1], np.array([(0, 0), (1, 2)], dtype=record_dtype), nrows=2, ncols=2, dtype=udt
     )
     assert A.isequal(expected)
-    A[:, :] = 0
+    A << 0
     zeros = Matrix.from_values([0, 0, 1, 1], [0, 1, 0, 1], 0, dtype=udt)
     assert A.isequal(zeros)
     A(A.S)[:, :] = 1

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1990,6 +1990,12 @@ def test_udt():
     v[:] = 1
     w[:] = np.array([1, 1, 1], dtype=np.uint8)
     assert v.isequal(w)
+    v[:] = 0
+    v << 1
+    assert v.isequal(w)
+    v[:] = 0
+    v << (1, 1, 1)
+    assert v.isequal(w)
 
     indices, values = v.to_values()
     assert_array_equal(values, np.ones((2, 3), dtype=np.uint16))


### PR DESCRIPTION
This allows e.g `A << (1, 2, 3)` to assign a scalar to every value.  Before, we required `A[:, :] = (1, 2, 3)`.

I don't think there was any reason I didn't do this before other than I overlooked it.