### PR TITLE
Add __networkx_plugin__ to Matrix and variants

### DIFF
--- a/graphblas/core/infix.py
+++ b/graphblas/core/infix.py
@@ -155,6 +155,7 @@ class MatrixInfixExpr(InfixExprBase):
     ndim = 2
     output_type = MatrixExpression
     _is_transposed = False
+    __networkx_plugin__ = "graphblas"
 
     def __init__(self, left, right):
         super().__init__(left, right)
@@ -243,6 +244,7 @@ class MatrixEwiseAddExpr(MatrixInfixExpr):
     method_name = "ewise_add"
     _example_op = "plus"
     _infix = "|"
+    __networkx_plugin__ = "graphblas"
 
     _to_expr = _ewise_add_to_expr
 
@@ -252,6 +254,7 @@ class MatrixEwiseMultExpr(MatrixInfixExpr):
     method_name = "ewise_mult"
     _example_op = "times"
     _infix = "&"
+    __networkx_plugin__ = "graphblas"
 
     _to_expr = _ewise_mult_to_expr
 
@@ -261,6 +264,7 @@ class MatrixMatMulExpr(MatrixInfixExpr):
     method_name = "mxm"
     _example_op = "plus_times"
     _infix = "@"
+    __networkx_plugin__ = "graphblas"
 
     def __init__(self, left, right, *, nrows, ncols):
         super().__init__(left, right)

--- a/graphblas/core/matrix.py
+++ b/graphblas/core/matrix.py
@@ -87,6 +87,7 @@ class Matrix(BaseType):
     ndim = 2
     _is_transposed = False
     _name_counter = itertools.count()
+    __networkx_plugin__ = "graphblas"
 
     def __new__(cls, dtype=FP64, nrows=0, ncols=0, *, name=None):
         self = object.__new__(cls)
@@ -2306,6 +2307,7 @@ class MatrixExpression(BaseExpression):
     ndim = 2
     output_type = Matrix
     _is_transposed = False
+    __networkx_plugin__ = "graphblas"
 
     def __init__(
         self,
@@ -2432,6 +2434,7 @@ class MatrixIndexExpr(AmbiguousAssignOrExtract):
     ndim = 2
     output_type = Matrix
     _is_transposed = False
+    __networkx_plugin__ = "graphblas"
 
     def __init__(self, parent, resolved_indexes, nrows, ncols):
         super().__init__(parent, resolved_indexes)
@@ -2517,6 +2520,7 @@ class TransposedMatrix:
     ndim = 2
     _is_scalar = False
     _is_transposed = True
+    __networkx_plugin__ = "graphblas"
 
     def __init__(self, matrix):
         self._matrix = matrix


### PR DESCRIPTION
This requires changes to both NetworkX and graphblas-algorithms.

Passing a gb.Matrix into a NetworkX algorithm will now trigger the plugin behavior. No need to wrap the Matrix in a ga.Graph first.