### PR TITLE
Update notebooks to not use deprecated `gb.io.draw`

### DIFF
--- a/notebooks/Connected Components -- FastSV.ipynb
+++ b/notebooks/Connected Components -- FastSV.ipynb
@@ -21,10 +21,9 @@
     "from scipy.sparse import coo_array, eye\n",
     "import networkx as nx\n",
     "import matplotlib.pyplot as plt\n",
-    "import graphblas\n",
+    "import graphblas as gb\n",
     "from graphblas import Matrix, Vector, Scalar\n",
-    "from graphblas import unary, binary, monoid, semiring, op\n",
-    "from graphblas import io as gio"
+    "from graphblas import unary, binary, monoid, semiring, op"
    ]
   },
   {
@@ -136,7 +135,7 @@
    },
    "outputs": [],
    "source": [
-    "A = gio.from_scipy_sparse(A, name=\"A\")\n",
+    "A = gb.io.from_scipy_sparse(A, name=\"A\")\n",
     "# Size of the sparse matrix is 12x12 with 22 non-zero elements of type INT64"
    ]
   },
@@ -549,8 +548,8 @@
     }
    ],
    "source": [
-    "# graphblas.io.draw could do with a few more tunable options to improve pretty display\n",
-    "gio.draw(A)"
+    "# graphblas.viz.draw could do with a few more tunable options to improve pretty display\n",
+    "gb.viz.draw(A)"
    ]
   },
   {
@@ -2976,7 +2975,7 @@
     }
    ],
    "source": [
-    "A_sci = gio.to_scipy_sparse(AA, format=\"csr\")\n",
+    "A_sci = gb.io.to_scipy_sparse(AA, format=\"csr\")\n",
     "G_perm = nx.convert_matrix.from_scipy_sparse_array(A_sci)\n",
     "layout_perm = {p[k]: layout[k] for k in layout}\n",
     "nx.draw_networkx(G_perm, with_labels=True, node_size=500, font_color=\"w\", pos=layout_perm)"
@@ -3405,7 +3404,7 @@
     }
    ],
    "source": [
-    "AAA_sci = gio.to_scipy_sparse(AAA, format=\"csr\")\n",
+    "AAA_sci = gb.io.to_scipy_sparse(AAA, format=\"csr\")\n",
     "G_perm2 = nx.convert_matrix.from_scipy_sparse_array(AAA_sci)\n",
     "layout_perm2 = {p2[k]: layout_perm[k] for k in layout_perm}\n",
     "nx.draw_networkx(G_perm2, with_labels=True, node_size=500, font_color=\"w\", pos=layout_perm2)"
@@ -3671,7 +3670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Example B.1 -- Level BFS.ipynb
+++ b/notebooks/Example B.1 -- Level BFS.ipynb
@@ -22,8 +22,7 @@
     "import graphblas as gb\n",
     "from graphblas import Matrix, Vector, Scalar\n",
     "from graphblas import dtypes\n",
-    "from graphblas import unary, binary, monoid, semiring\n",
-    "from graphblas import io as gio"
+    "from graphblas import unary, binary, monoid, semiring"
    ]
   },
   {
@@ -56,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(A)"
+    "gb.viz.draw(A)"
    ]
   },
   {
@@ -220,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Example B.3 -- Parent BFS.ipynb
+++ b/notebooks/Example B.3 -- Parent BFS.ipynb
@@ -22,8 +22,7 @@
     "import graphblas as gb\n",
     "from graphblas import Matrix, Vector, Scalar\n",
     "from graphblas import dtypes\n",
-    "from graphblas import unary, binary, monoid, semiring\n",
-    "from graphblas import io as gio"
+    "from graphblas import unary, binary, monoid, semiring"
    ]
   },
   {
@@ -47,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(A)"
+    "gb.viz.draw(A)"
    ]
   },
   {
@@ -248,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Intro to GraphBLAS + SSSP example.ipynb
+++ b/notebooks/Intro to GraphBLAS + SSSP example.ipynb
@@ -10,10 +10,9 @@
     "import pandas as pd\n",
     "import networkx as nx\n",
     "import matplotlib.pyplot as plt\n",
-    "import graphblas\n",
+    "import graphblas as gb\n",
     "from graphblas import Matrix, Vector, Scalar\n",
-    "from graphblas import unary, binary, monoid, semiring\n",
-    "from graphblas import io as gio"
+    "from graphblas import unary, binary, monoid, semiring"
    ]
   },
   {
@@ -66,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(m)"
+    "gb.viz.draw(m)"
    ]
   },
   {
@@ -150,7 +149,7 @@
    "outputs": [],
    "source": [
     "# Look again at m and see that vertex 1 points to vertices 4 and 6 with the weights indicated\n",
-    "gio.draw(m)"
+    "gb.viz.draw(m)"
    ]
   },
   {
@@ -200,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(m)"
+    "gb.viz.draw(m)"
    ]
   },
   {
@@ -365,7 +364,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Louvain.ipynb
+++ b/notebooks/Louvain.ipynb
@@ -13,11 +13,10 @@
     "import matplotlib.pyplot as plt\n",
     "from collections import namedtuple\n",
     "from scipy.sparse import csr_array\n",
-    "import graphblas\n",
-    "from graphblas import Matrix, Vector\n",
+    "import graphblas as gb\n",
+    "from graphblas import Matrix, Vector, Scalar\n",
     "from graphblas import dtypes\n",
-    "from graphblas import unary, binary, monoid, semiring\n",
-    "import graphblas.io as gio"
+    "from graphblas import unary, binary, monoid, semiring"
    ]
   },
   {
@@ -46,30 +45,30 @@
     "        self.nn = nn\n",
     "        self.nc = nc\n",
     "        self.total_links_doubled = adj.reduce_scalar(monoid.plus, allow_empty=False).new()\n",
-    "        self.community_tmp = graphblas.Matrix(adj.dtype, nrows=nc, ncols=nn)\n",
-    "        self.community = graphblas.Matrix(adj.dtype, nrows=nc, ncols=nc)\n",
-    "        self.diag_mask = graphblas.Matrix.from_values(\n",
+    "        self.community_tmp = Matrix(adj.dtype, nrows=nc, ncols=nn)\n",
+    "        self.community = Matrix(adj.dtype, nrows=nc, ncols=nc)\n",
+    "        self.diag_mask = Matrix.from_values(\n",
     "            range(nc), range(nc), [True] * nc, nrows=nc, ncols=nc, dtype=dtypes.BOOL\n",
     "        )\n",
-    "        self.diag_matrix = graphblas.Matrix(adj.dtype, nrows=nc, ncols=nc)\n",
-    "        self.diag_vector = graphblas.Vector(adj.dtype, size=nc)\n",
-    "        self.modularity = graphblas.Vector(dtypes.FP64, size=nc)\n",
-    "        self.stored_community = graphblas.Vector(dtypes.INT64, size=nc)\n",
+    "        self.diag_matrix = Matrix(adj.dtype, nrows=nc, ncols=nc)\n",
+    "        self.diag_vector = Vector(adj.dtype, size=nc)\n",
+    "        self.modularity = Vector(dtypes.FP64, size=nc)\n",
+    "        self.stored_community = Vector(dtypes.INT64, size=nc)\n",
     "        self.beyond_last_index = nn\n",
-    "        self.beyond_last = graphblas.Vector.from_values([self.beyond_last_index], [1], size=nc)\n",
-    "        self.ki_all = graphblas.Vector(dtypes.FP64, size=nn)\n",
+    "        self.beyond_last = Vector.from_values([self.beyond_last_index], [1], size=nc)\n",
+    "        self.ki_all = Vector(dtypes.FP64, size=nn)\n",
     "        self.ki_all << adj.reduce_columnwise(monoid.plus)\n",
-    "        self.sigma_total = graphblas.Vector(dtypes.FP64, size=nc)\n",
-    "        self.ki_in = graphblas.Vector(dtypes.FP64, size=nc)\n",
-    "        self.max_modularity_delta = graphblas.Scalar(dtypes.FP64)\n",
-    "        self.max_mask = graphblas.Vector(dtypes.BOOL, size=nc)\n",
+    "        self.sigma_total = Vector(dtypes.FP64, size=nc)\n",
+    "        self.ki_in = Vector(dtypes.FP64, size=nc)\n",
+    "        self.max_modularity_delta = Scalar(dtypes.FP64)\n",
+    "        self.max_mask = Vector(dtypes.BOOL, size=nc)\n",
     "        self._ident_comms = None\n",
     "\n",
     "    def _get_comms_identity(self):\n",
     "        # Build the identity matrix, assigning each node to its own community\n",
     "        if self._ident_comms is None:\n",
     "            nn, nc = self.nn, self.nc\n",
-    "            self._ident_comms = graphblas.Matrix.from_values(\n",
+    "            self._ident_comms = Matrix.from_values(\n",
     "                range(nn), range(nn), [1] * nn, nrows=nc, ncols=nn\n",
     "            )\n",
     "        return self._ident_comms\n",
@@ -185,7 +184,7 @@
     "        # Compact comms\n",
     "        rows, cols, vals = comms.to_values()\n",
     "        nonzero_rows = list(sorted(set(rows)))\n",
-    "        compact_comms = graphblas.Matrix(comms.dtype, nrows=len(nonzero_rows), ncols=self.nn)\n",
+    "        compact_comms = Matrix(comms.dtype, nrows=len(nonzero_rows), ncols=self.nn)\n",
     "        compact_comms << comms[nonzero_rows, :]\n",
     "\n",
     "        return compact_comms"
@@ -221,8 +220,8 @@
     "        # Compress the adjacency graph\n",
     "        nc = comms.nrows\n",
     "        prev_adj = adj.adj\n",
-    "        adj_tmp = graphblas.Matrix(prev_adj.dtype, nrows=nc, ncols=prev_adj.nrows)\n",
-    "        adj = graphblas.Matrix(prev_adj.dtype, nrows=nc, ncols=nc)\n",
+    "        adj_tmp = Matrix(prev_adj.dtype, nrows=nc, ncols=prev_adj.nrows)\n",
+    "        adj = Matrix(prev_adj.dtype, nrows=nc, ncols=nc)\n",
     "        adj_tmp << comms.mxm(prev_adj)\n",
     "        adj << adj_tmp.mxm(comms.T)\n",
     "        adj = AdjMatrix(adj)\n",
@@ -273,7 +272,7 @@
     "        [0, 0, 1, 0, 0, 1, 0],\n",
     "    ]\n",
     ")\n",
-    "g = gio.from_numpy(m)"
+    "g = gb.io.from_numpy(m)"
    ]
   },
   {
@@ -291,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(g)"
+    "gb.viz.draw(g)"
    ]
   },
   {
@@ -373,7 +372,7 @@
     "        [0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
     "    ]\n",
     ")\n",
-    "g = gio.from_numpy(m)"
+    "g = gb.io.from_numpy(m)"
    ]
   },
   {
@@ -472,7 +471,7 @@
     "        [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],\n",
     "    ]\n",
     ")\n",
-    "g = gio.from_numpy(m)"
+    "g = gb.io.from_numpy(m)"
    ]
   },
   {
@@ -523,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Pagerank Demo.ipynb
+++ b/notebooks/Pagerank Demo.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import graphblas as gb\n",
     "from graphblas import Matrix, Vector\n",
-    "from graphblas import unary, binary, monoid, semiring, dtypes\n",
-    "from graphblas import io as gio"
+    "from graphblas import unary, binary, monoid, semiring, dtypes"
    ]
   },
   {
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gio.draw(A)"
+    "gb.viz.draw(A)"
    ]
   },
   {
@@ -286,7 +286,7 @@
    "source": [
     "import networkx as nx\n",
     "\n",
-    "g = gio.to_networkx(A)\n",
+    "g = gb.io.to_networkx(A)\n",
     "g.edges()"
    ]
   },
@@ -333,7 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "B = gio.from_networkx(big, dtype=\"UINT8\")\n",
+    "B = gb.io.from_networkx(big, dtype=\"UINT8\")\n",
     "B"
    ]
   },
@@ -415,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some notebooks could probably stand to benefit from a close readthrough and updated to use more modern `python-graphblas` syntax.