### PR TITLE
Add GxB sort methods

### DIFF
--- a/graphblas/core/base.py
+++ b/graphblas/core/base.py
@@ -4,14 +4,13 @@ from .. import backend, config
 from .. import replace as replace_singleton
 from ..dtypes import BOOL
 from ..exceptions import check_status
-from . import NULL, ffi
+from . import NULL
 from .descriptor import lookup as descriptor_lookup
 from .expr import AmbiguousAssignOrExtract, Updater
 from .mask import Mask
 from .operator import UNKNOWN_OPCLASS, binary_from_string, find_opclass, get_typed_op
 from .utils import _Pointer, libget, output_type
 
-CData = ffi.CData
 _recorder = ContextVar("recorder")
 _prev_recorder = None
 

--- a/graphblas/core/descriptor.py
+++ b/graphblas/core/descriptor.py
@@ -72,6 +72,7 @@ def lookup(
     mask_structure=False,
     transpose_first=False,
     transpose_second=False,
+    create=False,
 ):
     key = (
         output_replace,
@@ -80,7 +81,7 @@ def lookup(
         transpose_first,
         transpose_second,
     )
-    if key not in _desc_map:  # pragma: no cover (unnecessary)
+    if create or key not in _desc_map:
         # We currently don't need this block of code!
         # All 32 possible descriptors are currently already added to _desc_map.
         # Nevertheless, this code may be useful some day, because we will want
@@ -102,5 +103,8 @@ def lookup(
                     check_status_carg(
                         lib.GrB_Descriptor_set(desc[0], field, val), "Descriptor", desc[0]
                     )
-        _desc_map[key] = Descriptor(desc[0], "custom_descriptor", *key)
+        rv = Descriptor(desc[0], "custom_descriptor", *key)
+        if not create:  # pragma: no cover (unnecessary)
+            _desc_map[key] = rv
+        return rv
     return _desc_map[key]

--- a/graphblas/core/operator.py
+++ b/graphblas/core/operator.py
@@ -1454,7 +1454,7 @@ class IndexUnaryOp(OpBase):
             op = getattr(indexunary, name)
             typed_op = op._typed_ops[BOOL]
             output_type = op.types[BOOL]
-            if UINT64 not in op.types:
+            if UINT64 not in op.types:  # pragma: no branch (safety)
                 op.types[UINT64] = output_type
                 op._typed_ops[UINT64] = typed_op
                 op.coercions[UINT64] = BOOL
@@ -1462,7 +1462,7 @@ class IndexUnaryOp(OpBase):
             op = getattr(indexunary, name)
             typed_op = op._typed_ops[INT64]
             output_type = op.types[INT64]
-            if UINT64 not in op.types:
+            if UINT64 not in op.types:  # pragma: no branch (safety)
                 op.types[UINT64] = output_type
                 op._typed_ops[UINT64] = typed_op
                 op.coercions[UINT64] = INT64

--- a/graphblas/core/ss/descriptor.py
+++ b/graphblas/core/ss/descriptor.py
@@ -13,14 +13,7 @@ str_to_compression = {
 }
 
 
-def get_nthreads_descriptor(nthreads, _cache=True):
-    nthreads = max(0, int(nthreads))
-    key = ("nthreads", nthreads)
-    if _cache and key in _desc_map:
-        return _desc_map[key]
-    desc_obj = ffi.new("GrB_Descriptor*")
-    lib.GrB_Descriptor_new(desc_obj)
-    desc = Descriptor(desc_obj[0], f"nthreads{nthreads}")
+def set_nthreads(desc, nthreads):
     check_status(
         lib.GxB_Desc_set(
             desc._carg,
@@ -29,6 +22,17 @@ def get_nthreads_descriptor(nthreads, _cache=True):
         ),
         desc,
     )
+
+
+def get_nthreads_descriptor(nthreads, _cache=True):
+    nthreads = max(0, int(nthreads))
+    key = ("nthreads", nthreads)
+    if _cache and key in _desc_map:
+        return _desc_map[key]
+    desc_obj = ffi.new("GrB_Descriptor*")
+    lib.GrB_Descriptor_new(desc_obj)
+    desc = Descriptor(desc_obj[0], f"nthreads{nthreads}")
+    set_nthreads(desc, nthreads)
     if _cache:
         _desc_map[key] = desc
     return desc

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -3844,7 +3844,7 @@ class ss:
             name=name,
         )
 
-    def sort(self, op=binary.lt, *, order="rowwise", permutation=True, values=True, nthreads=None):
+    def sort(self, op=binary.lt, order="rowwise", *, permutation=True, values=True, nthreads=None):
         """GxB_Matrix_sort to sort values along the rows (default) or columns of the Matrix
 
         Sorting moves all the elements to the left (if rowwise) or top (if columnwise) just

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -3844,7 +3844,7 @@ class ss:
             name=name,
         )
 
-    def sort(self, op=binary.lt, order="rowwise", *, permutation=True, values=True, nthreads=None):
+    def sort(self, op=binary.lt, order="rowwise", *, values=True, permutation=True, nthreads=None):
         """GxB_Matrix_sort to sort values along the rows (default) or columns of the Matrix
 
         Sorting moves all the elements to the left (if rowwise) or top (if columnwise) just
@@ -3859,20 +3859,20 @@ class ss:
         order : {"rowwise", "columnwise"}, optional
             Whether to sort rowwise or columnwise. Rowwise shifts all values to the left,
             and columnwise shifts all values to the top. The default is "rowwise".
+        values : bool, default=True
+            Whether to return values; will return `None` for values if `False`.
         permutation : bool, default=True
             Whether to compute the permutation Matrix that has the original column
             indices (if rowwise) or row indices (if columnwise) of the sorted values.
             Will return None if `False`.
-        values : bool, default=True
-            Whether to return values; will return `None` for values if `False`.
         nthreads : int, optional
             The maximum number of threads to use for this operation.
             None, 0 or negative nthreads means to use the default number of threads.
 
         Returns
         -------
-        Matrix[dtype=UINT64] : Permutation
         Matrix : Values
+        Matrix[dtype=UINT64] : Permutation
 
         See Also
         --------
@@ -3918,7 +3918,7 @@ class ss:
             ),
             parent,
         )
-        return P, C
+        return C, P
 
     def serialize(self, compression="default", level=None, *, nthreads=None):
         """Serialize a Matrix to bytes (as numpy array) using SuiteSparse GxB_Matrix_serialize.

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -3855,6 +3855,7 @@ class ss:
         op : :class:`~graphblas.core.operator.BinaryOp`, optional
             Binary operator with a bool return type used to sort the values.
             For example, `binary.lt` (the default) sorts the smallest elements first.
+            Ties are broken according to indices (smaller first).
         order : {"rowwise", "columnwise"}, optional
             Whether to sort rowwise or columnwise. Rowwise shifts all values to the left,
             and columnwise shifts all values to the top. The default is "rowwise".

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -1491,7 +1491,7 @@ class ss:
             name=name,
         )
 
-    def sort(self, op=binary.lt, *, permutation=True, values=True, nthreads=None):
+    def sort(self, op=binary.lt, *, values=True, permutation=True, nthreads=None):
         """GxB_Vector_sort to sort values of the Vector
 
         Sorting moves all the elements to the left just like `compactify`.
@@ -1503,19 +1503,19 @@ class ss:
             Binary operator with a bool return type used to sort the values.
             For example, `binary.lt` (the default) sorts the smallest elements first.
             Ties are broken according to indices (smaller first).
+        values : bool, default=True
+            Whether to return values; will return `None` for values if `False`.
         permutation : bool, default=True
             Whether to compute the permutation Vector that has the original indices of the
             sorted values. Will return None if `False`.
-        values : bool, default=True
-            Whether to return values; will return `None` for values if `False`.
         nthreads : int, optional
             The maximum number of threads to use for this operation.
             None, 0 or negative nthreads means to use the default number of threads.
 
         Returns
         -------
-        Vector[dtype=UINT64] : permutation
         Vector : values
+        Vector[dtype=UINT64] : permutation
 
         See Also
         --------
@@ -1553,7 +1553,7 @@ class ss:
             ),
             parent,
         )
-        return p, w
+        return w, p
 
     def serialize(self, compression="default", level=None, *, nthreads=None):
         """Serialize a Vector to bytes (as numpy array) using SuiteSparse GxB_Vector_serialize.

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -1502,6 +1502,7 @@ class ss:
         op : :class:`~graphblas.core.operator.BinaryOp`, optional
             Binary operator with a bool return type used to sort the values.
             For example, `binary.lt` (the default) sorts the smallest elements first.
+            Ties are broken according to indices (smaller first).
         permutation : bool, default=True
             Whether to compute the permutation Vector that has the original indices of the
             sorted values. Will return None if `False`.

--- a/graphblas/monoid/numpy.py
+++ b/graphblas/monoid/numpy.py
@@ -85,6 +85,7 @@ if _supports_complex:
 
 # To increase import speed, only call njit when `_config.get("mapnumpy")` is False
 if _config.get("mapnumpy") or type(_numba.njit(lambda x, y: _np.fmax(x, y))(1, 2)) is not float:
+    # Incorrect behavior was introduced in numba 0.56.2 and numpy 1.23
     # See: https://github.com/numba/numba/issues/8478
     _monoid_identities["fmax"].update(
         {

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -4040,15 +4040,15 @@ def test_ss_sort(A):
         ncols=A.ncols,
     )
     for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
-        P, C = A.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
-        if permutation:
-            assert P.isequal(expected_P)
-        else:
-            assert P is None
+        C, P = A.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
         if values:
             assert C.isequal(expected_C)
         else:
             assert C is None
+        if permutation:
+            assert P.isequal(expected_P)
+        else:
+            assert P is None
 
     expected_P = Matrix.from_coo(
         [0, 0, 0, 1, 2, 0, 1, 0, 1, 0, 1, 0],
@@ -4065,15 +4065,15 @@ def test_ss_sort(A):
         ncols=A.ncols,
     )
     for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
-        P, C = A.ss.sort(order="col", permutation=permutation, values=values, nthreads=nthreads)
-        if permutation:
-            assert P.isequal(expected_P)
-        else:
-            assert P is None
+        C, P = A.ss.sort(order="col", permutation=permutation, values=values, nthreads=nthreads)
         if values:
             assert C.isequal(expected_C)
         else:
             assert C is None
+        if permutation:
+            assert P.isequal(expected_P)
+        else:
+            assert P is None
 
     with pytest.raises(DomainMismatch):
         A.ss.sort("+")
@@ -4092,6 +4092,6 @@ def test_ss_sort(A):
         nrows=A.nrows,
         ncols=A.ncols,
     )
-    P, C = A.ss.sort(binary.gt, order="col")
+    C, P = A.ss.sort(binary.gt, order="col")
     assert P.isequal(expected_P)
     assert C.isequal(expected_C)

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -13,6 +13,7 @@ from graphblas import agg, backend, binary, dtypes, indexunary, monoid, select, 
 from graphblas.core import lib
 from graphblas.exceptions import (
     DimensionMismatch,
+    DomainMismatch,
     EmptyObject,
     IndexOutOfBound,
     InvalidObject,
@@ -4015,3 +4016,78 @@ def test_from_list_of_dicts():
         Matrix.from_dicts(list_of_dicts, order="colwise", ncols=5)
     with pytest.raises(InvalidObject):
         Matrix.from_dicts(list_of_dicts, ncols=1)
+
+
+@pytest.mark.skipif("not suitesparse")
+def test_ss_sort(A):
+    A[3, 0] = 9
+    expected_P = Matrix.from_coo(
+        [0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6],
+        [0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 2],
+        [1, 3, 6, 4, 5, 2, 0, 5, 2, 4, 2, 3],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    expected_C = Matrix.from_coo(
+        [0, 0, 1, 1, 2, 3, 3, 4, 5, 6, 6, 6],
+        [0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 2],
+        [2, 3, 4, 8, 1, 3, 9, 7, 1, 3, 5, 7],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
+        P, C = A.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
+        if permutation:
+            assert P.isequal(expected_P)
+        else:
+            assert P is None
+        if values:
+            assert C.isequal(expected_C)
+        else:
+            assert C is None
+
+    expected_P = Matrix.from_coo(
+        [0, 0, 0, 1, 2, 0, 1, 0, 1, 0, 1, 0],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+        [3, 0, 5, 3, 6, 0, 6, 6, 1, 2, 4, 1],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    expected_C = Matrix.from_coo(
+        [0, 0, 0, 1, 2, 0, 1, 0, 1, 0, 1, 0],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+        [9, 2, 1, 3, 5, 3, 7, 3, 8, 1, 7, 4],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
+        P, C = A.ss.sort(order="col", permutation=permutation, values=values, nthreads=nthreads)
+        if permutation:
+            assert P.isequal(expected_P)
+        else:
+            assert P is None
+        if values:
+            assert C.isequal(expected_C)
+        else:
+            assert C is None
+
+    with pytest.raises(DomainMismatch):
+        A.ss.sort("+")
+
+    expected_P = Matrix.from_coo(
+        [0, 0, 0, 1, 2, 0, 1, 0, 1, 0, 1, 0],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+        [3, 0, 6, 3, 5, 6, 0, 1, 6, 4, 2, 1],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    expected_C = Matrix.from_coo(
+        [0, 0, 0, 1, 2, 0, 1, 0, 1, 0, 1, 0],
+        [0, 1, 2, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+        [9, 2, 5, 3, 1, 7, 3, 8, 3, 7, 1, 4],
+        nrows=A.nrows,
+        ncols=A.ncols,
+    )
+    P, C = A.ss.sort(binary.gt, order="col")
+    assert P.isequal(expected_P)
+    assert C.isequal(expected_C)

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2404,14 +2404,13 @@ def test_to_dict(v):
 
 @pytest.mark.skipif("not suitesparse")
 def test_ss_sort(v):
-    # For equal values, are indices guaranteed to be sorted?
-    expected_p1 = Vector.from_coo([0, 1, 2, 3], [6, 1, 3, 4], size=7)
-    expected_p2 = Vector.from_coo([0, 1, 2, 3], [6, 1, 3, 4], size=7)
+    # For equal values, indices are guaranteed to be sorted
+    expected_p = Vector.from_coo([0, 1, 2, 3], [6, 1, 3, 4], size=7)
     expected_w = Vector.from_coo([0, 1, 2, 3], [0, 1, 1, 2], size=7)
     for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
         p, w = v.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
         if permutation:
-            assert p.isequal(expected_p1) or p.isequal(expected_p2)
+            assert p.isequal(expected_p)
         else:
             assert p is None
         if values:
@@ -2423,3 +2422,12 @@ def test_ss_sort(v):
     assert w.isequal(expected)
     with pytest.raises(DomainMismatch):
         v.ss.sort(binary.plus)
+
+    # Like compactify
+    p, _ = v.ss.sort(lambda x, y: False, values=False)
+    expected_p = Vector.from_coo([0, 1, 2, 3], [1, 3, 4, 6], size=7)
+    assert p.isequal(expected_p)
+    # reversed
+    p, _ = v.ss.sort(binary.pair[bool], values=False)
+    expected_p = Vector.from_coo([0, 1, 2, 3], [6, 4, 3, 1], size=7)
+    assert p.isequal(expected_p)

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -2412,26 +2412,26 @@ def test_ss_sort(v):
     expected_p = Vector.from_coo([0, 1, 2, 3], [6, 1, 3, 4], size=7)
     expected_w = Vector.from_coo([0, 1, 2, 3], [0, 1, 1, 2], size=7)
     for permutation, values, nthreads in itertools.product([True, False], [True, False], [None, 4]):
-        p, w = v.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
-        if permutation:
-            assert p.isequal(expected_p)
-        else:
-            assert p is None
+        w, p = v.ss.sort(permutation=permutation, values=values, nthreads=nthreads)
         if values:
             assert w.isequal(expected_w)
         else:
             assert w is None
-    _, w = v.ss.sort(">", permutation=False)
+        if permutation:
+            assert p.isequal(expected_p)
+        else:
+            assert p is None
+    w, _ = v.ss.sort(">", permutation=False)
     expected = Vector.from_coo([0, 1, 2, 3], [2, 1, 1, 0], size=7)
     assert w.isequal(expected)
     with pytest.raises(DomainMismatch):
         v.ss.sort(binary.plus)
 
     # Like compactify
-    p, _ = v.ss.sort(lambda x, y: False, values=False)
+    _, p = v.ss.sort(lambda x, y: False, values=False)
     expected_p = Vector.from_coo([0, 1, 2, 3], [1, 3, 4, 6], size=7)
     assert p.isequal(expected_p)
     # reversed
-    p, _ = v.ss.sort(binary.pair[bool], values=False)
+    _, p = v.ss.sort(binary.pair[bool], values=False)
     expected_p = Vector.from_coo([0, 1, 2, 3], [6, 4, 3, 1], size=7)
     assert p.isequal(expected_p)


### PR DESCRIPTION
Closes https://github.com/python-graphblas/python-graphblas/issues/290. I've been sitting on this for a couple weeks. It still needs tests and documentation, but everything seems to work.

@jim22k, would you like to take a moment to consider the options of having `foo_rowwise` and `foo_columnwise` methods vs having `foo(order="rowwise")`? Here are the methods for each convention, including `sort_rowwise` as in this PR.

These have `order="rowwise"` keyword argument:
- `Matrix.from_dicts`
- `A.to_dicts`
- `A.ss.flatten`
- `A.ss.reshape`
- `v.ss.reshape`

These use `_rowwise` and `_columnwise` suffix:
- `A.reduce_rowwise`
- `A.ss.scan_rowwise`
- `A.ss.selectk_rowwise`
- `A.ss.compactify_rowwise`
- `A.ss.sort_rowwise`

Why not `A.ss.flatten_rowwise` and `A.ss.flatten_columnwise`?
What do we think about e.g. `A.reduce(order="rowwise")`?

Also, this adds some functionality with descriptors. Cleaning up these descriptors can provide a path for implementing https://github.com/python-graphblas/python-graphblas/issues/20.

Finally, what names should we give the objects returned from `sort`? It's unusual to have an API that returns multiple Matrix or Vector objects.