### PR TITLE
Add "complete" option to `wait` methods

### DIFF
--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -2570,6 +2570,10 @@ def test_wait(A):
     A2 = A.dup()
     A2.wait()
     assert A2.isequal(A)
+    A2.wait("materialize")
+    A2.wait("complete")
+    with pytest.raises(ValueError):
+        A2.wait("badmode")
 
 
 def test_pickle(A):

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -312,6 +312,10 @@ def test_invert():
 
 def test_wait(s):
     s.wait()
+    s.wait("materialize")
+    s.wait("complete")
+    with pytest.raises(ValueError):
+        s.wait("badmode")
 
 
 @autocompute

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1350,6 +1350,10 @@ def test_wait(v):
     v2 = v.dup()
     v2.wait()
     assert v2.isequal(v)
+    v2.wait("materialize")
+    v2.wait("complete")
+    with pytest.raises(ValueError):
+        v2.wait("badmode")
 
 
 def test_pickle(v):


### PR DESCRIPTION
I don't know how useful this will be in Python, but including for completeness. I'm not fond of the names "materialize" and "complete", but these are what are in the spec.

I added this as an option to `.wait`, because this functionality probably isn't going to be used that often and I didn't want to make a new method.