### PR TITLE
Deprecate `ss.scan_rowwise`, `ss.compactify_rowwise`, and `ss.selectk_rowwise`

### DIFF
--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -3486,28 +3486,63 @@ class ss:
     def head(self, n=10, dtype=None, *, sort=False):
         return head(self._parent, n, dtype, sort=sort)
 
-    def scan_columnwise(self, op=monoid.plus, *, name=None):
-        """Perform a prefix scan across columns with the given monoid.
+    def scan(self, op=monoid.plus, order="rowwise", *, name=None):
+        """Perform a prefix scan across rows (default) or columns with the given monoid.
 
         For example, use `monoid.plus` (the default) to perform a cumulative sum,
         and `monoid.times` for cumulative product.  Works with any monoid.
 
         Returns
         -------
-        Vector
+        Matrix
         """
+        order = get_order(order)
+        parent = self._parent
+        if order == "columnwise":
+            parent = parent.T
+        return prefix_scan(parent, op, name=name, within="scan")
+
+    def scan_columnwise(self, op=monoid.plus, *, name=None):
+        """Perform a prefix scan across columns with the given monoid.
+
+        .. deprecated:: 2022.11.1
+            `Matrix.ss.scan_columnwise` will be removed in a future release.
+            Use `Matrix.ss.scan(order="columnwise")` instead.
+            Will be removed in version 2023.7.0 or later
+
+        For example, use `monoid.plus` (the default) to perform a cumulative sum,
+        and `monoid.times` for cumulative product.  Works with any monoid.
+
+        Returns
+        -------
+        Matrix
+        """
+        warnings.warn(
+            "`Matrix.ss.scan_columnwise` is deprecated; "
+            'please use `Matrix.ss.scan(order="columnwise")` instead.',
+            DeprecationWarning,
+        )
         return prefix_scan(self._parent.T, op, name=name, within="scan_columnwise")
 
     def scan_rowwise(self, op=monoid.plus, *, name=None):
         """Perform a prefix scan across rows with the given monoid.
 
+        .. deprecated:: 2022.11.1
+            `Matrix.ss.scan_rowwise` will be removed in a future release.
+            Use `Matrix.ss.scan` instead.
+            Will be removed in version 2023.7.0 or later
+
         For example, use `monoid.plus` (the default) to perform a cumulative sum,
         and `monoid.times` for cumulative product.  Works with any monoid.
 
         Returns
         -------
-        Vector
+        Matrix
         """
+        warnings.warn(
+            "`Matrix.ss.scan_rowwise` is deprecated; please use `Matrix.ss.scan` instead.",
+            DeprecationWarning,
+        )
         return prefix_scan(self._parent, op, name=name, within="scan_rowwise")
 
     def flatten(self, order="rowwise", *, name=None):
@@ -3608,8 +3643,8 @@ class ss:
         )
         return rv
 
-    def selectk_rowwise(self, how, k, *, name=None):
-        """Select (up to) k elements from each row.
+    def selectk(self, how, k, order="rowwise", *, name=None):
+        """Select (up to) k elements from each row (default) or column.
 
         Parameters
         ----------
@@ -3623,6 +3658,57 @@ class ss:
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
         """
         # TODO: largest, smallest, random_weighted
+        order = get_order(order)
+        how = how.lower()
+        if order == "rowwise":
+            fmt = "hypercsr"
+            indices = "col_indices"
+            sort_axis = "sorted_cols"
+        else:
+            fmt = "hypercsc"
+            indices = "row_indices"
+            sort_axis = "sorted_rows"
+        if how == "random":
+            choose_func = choose_random
+            is_random = True
+            do_sort = False
+        elif how == "first":
+            choose_func = choose_first
+            is_random = False
+            do_sort = True
+        elif how == "last":
+            choose_func = choose_last
+            is_random = False
+            do_sort = True
+        else:
+            raise ValueError('`how` argument must be one of: "random", "first", "last"')
+        return self._select_random(
+            k, fmt, indices, sort_axis, choose_func, is_random, do_sort, name
+        )
+
+    def selectk_rowwise(self, how, k, *, name=None):
+        """Select (up to) k elements from each row.
+
+        .. deprecated:: 2022.11.1
+            `Matrix.ss.selectk_rowwise` will be removed in a future release.
+            Use `Matrix.ss.selectk` instead.
+            Will be removed in version 2023.7.0 or later
+
+        Parameters
+        ----------
+        how : str
+            "random": choose k elements with equal probability
+            "first": choose the first k elements
+            "last": choose the last k elements
+        k : int
+            The number of elements to choose from each row
+
+        **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+        """
+        warnings.warn(
+            "`Matrix.ss.selectk_rowwise` is deprecated; please use `Matrix.ss.selectk` instead.",
+            DeprecationWarning,
+        )
         how = how.lower()
         fmt = "hypercsr"
         indices = "col_indices"
@@ -3640,13 +3726,18 @@ class ss:
             is_random = False
             do_sort = True
         else:
-            raise ValueError('`how` argument must be one of: "random"')
+            raise ValueError('`how` argument must be one of: "random", "first", "last"')
         return self._select_random(
             k, fmt, indices, sort_axis, choose_func, is_random, do_sort, name
         )
 
     def selectk_columnwise(self, how, k, *, name=None):
         """Select (up to) k elements from each column.
+
+        .. deprecated:: 2022.11.1
+            `Matrix.ss.selectk_columnwise` will be removed in a future release.
+            Use `Matrix.ss.selectk(order="columnwise")` instead.
+            Will be removed in version 2023.7.0 or later
 
         Parameters
         ----------
@@ -3659,6 +3750,11 @@ class ss:
 
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
         """
+        warnings.warn(
+            "`Matrix.ss.selectk_columnwise` is deprecated; "
+            'please use `Matrix.ss.selectk(order="columnwise")` instead.',
+            DeprecationWarning,
+        )
         how = how.lower()
         fmt = "hypercsc"
         indices = "row_indices"
@@ -3700,6 +3796,51 @@ class ss:
             name=name,
         )
 
+    def compactify(
+        self, how="first", k=None, order="rowwise", *, reverse=False, asindex=False, name=None
+    ):
+        """Shift all values to the left (or up) so all values in a row (or column) are contiguous.
+
+        This returns a new Matrix.
+
+        Parameters
+        ----------
+        how : {"first", "last", "smallest", "largest", "random"}, optional
+            How to compress the values:
+            - first : take the values furthest to the left (or top)
+            - last : take the values furthest to the right (or bottom)
+            - smallest : take the smallest values (if tied, may take any)
+            - largest : take the largest values (if tied, may take any)
+            - random : take values randomly with equal probability and without replacement
+              Chosen values may not be ordered randomly
+        k : int, optional
+            The number of columns (or rows) of the returned Matrix.  If not specified,
+            then the Matrix will be "compacted" to the smallest ncols (or nrows) that
+            doesn't lose values.
+        order : {"rowwise", "columnwise"}, optional
+            Whether to compactify rowwise or columnwise. Rowwise shifts all values
+            to the left, and columnwise shifts all values to the top.
+            The default is "rowwise".
+        reverse : bool, default False
+            Reverse the values in each row (or column) when True
+        asindex : bool, default False
+            Return the column (or row) index of the value when True.  If there are ties
+            for "smallest" and "largest", then any valid index may be returned.
+
+        **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+
+        """
+        order = get_order(order)
+        if order == "rowwise":
+            fmt = "hypercsr"
+            dimname = "ncols"
+            indices = "col_indices"
+        else:
+            fmt = "hypercsc"
+            dimname = "nrows"
+            indices = "row_indices"
+        return self._compactify(how, reverse, asindex, dimname, k, fmt, indices, name)
+
     def compactify_rowwise(
         self, how="first", ncols=None, *, reverse=False, asindex=False, name=None
     ):
@@ -3730,6 +3871,11 @@ class ss:
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
 
         """
+        warnings.warn(
+            "`Matrix.ss.compactify_rowwise` is deprecated; "
+            "please use `Matrix.ss.compactify` instead.",
+            DeprecationWarning,
+        )
         return self._compactify(
             how, reverse, asindex, "ncols", ncols, "hypercsr", "col_indices", name
         )
@@ -3764,6 +3910,11 @@ class ss:
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
 
         """
+        warnings.warn(
+            "`Matrix.ss.compactify_columnwise` is deprecated; "
+            'please use `Matrix.ss.compactify(order="columnwise")` instead.',
+            DeprecationWarning,
+        )
         return self._compactify(
             how, reverse, asindex, "nrows", nrows, "hypercsc", "row_indices", name
         )

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3178,39 +3178,39 @@ def test_infix_sugar(A):
 @pytest.mark.skipif("not suitesparse")
 @pytest.mark.slow
 def test_ss_random(A):
-    R = A.ss.selectk_rowwise("random", 1)
+    R = A.ss.selectk("random", 1)
     counts = R.reduce_rowwise(agg.count).new()
     expected = Vector.from_coo(range(A.ncols), 1)
     assert counts.isequal(expected)
 
-    R = A.ss.selectk_columnwise("random", 1)
+    R = A.ss.selectk("random", 1, order="col")
     counts = R.reduce_columnwise(agg.count).new()
     expected = Vector.from_coo(range(A.nrows), 1)
     assert counts.isequal(expected)
 
-    R = A.ss.selectk_rowwise("random", 2)
+    R = A.ss.selectk("random", 2)
     counts = R.reduce_rowwise(agg.count).new()
     assert counts.reduce(monoid.min).new() == 1
     assert counts.reduce(monoid.max).new() == 2
 
     # test iso
     A(A.S) << 1
-    R = A.ss.selectk_rowwise("random", 1)
+    R = A.ss.selectk("random", 1)
     counts = R.reduce_rowwise(agg.count).new()
     expected = Vector.from_coo(range(A.ncols), 1)
     assert counts.isequal(expected)
 
     with pytest.raises(ValueError):
-        A.ss.selectk_rowwise("bad", 1)
+        A.ss.selectk("bad", 1)
     with pytest.raises(ValueError):
-        A.ss.selectk_columnwise("bad", 1)
+        A.ss.selectk("bad", 1, order="col")
     with pytest.raises(ValueError):
-        A.ss.selectk_columnwise("random", -1)
+        A.ss.selectk("random", -1, order="columnwise")
 
 
 @pytest.mark.skipif("not suitesparse")
 def test_ss_firstk(A):
-    B = A.ss.selectk_rowwise("first", 1)
+    B = A.ss.selectk("first", 1)
     expected = Matrix.from_coo(
         [0, 1, 2, 3, 4, 5, 6],
         [1, 4, 5, 0, 5, 2, 2],
@@ -3220,7 +3220,7 @@ def test_ss_firstk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_rowwise("first", 2)
+    B = A.ss.selectk("first", 2)
     expected = Matrix.from_coo(
         [3, 0, 3, 5, 6, 0, 6, 1, 2, 4, 1],
         [0, 1, 2, 2, 2, 3, 3, 4, 5, 5, 6],
@@ -3230,10 +3230,10 @@ def test_ss_firstk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_rowwise("first", 3)
+    B = A.ss.selectk("first", 3)
     assert B.isequal(A)
 
-    B = A.ss.selectk_columnwise("first", 1)
+    B = A.ss.selectk("first", 1, order="col")
     expected = Matrix.from_coo(
         [3, 0, 3, 0, 1, 2, 1],
         [0, 1, 2, 3, 4, 5, 6],
@@ -3243,7 +3243,7 @@ def test_ss_firstk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_columnwise("first", 2)
+    B = A.ss.selectk("first", 2, order="col")
     expected = Matrix.from_coo(
         [3, 0, 3, 5, 0, 6, 1, 6, 2, 4, 1],
         [0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
@@ -3253,13 +3253,13 @@ def test_ss_firstk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_columnwise("first", 3)
+    B = A.ss.selectk("first", 3, order="col")
     assert B.isequal(A)
 
 
 @pytest.mark.skipif("not suitesparse")
 def test_ss_lastk(A):
-    B = A.ss.selectk_rowwise("last", 1)
+    B = A.ss.selectk("last", 1)
     expected = Matrix.from_coo(
         [0, 3, 5, 6, 2, 4, 1],
         [3, 2, 2, 4, 5, 5, 6],
@@ -3269,7 +3269,7 @@ def test_ss_lastk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_rowwise("last", 2)
+    B = A.ss.selectk("last", 2)
     expected = Matrix.from_coo(
         [3, 0, 3, 5, 0, 6, 1, 6, 2, 4, 1],
         [0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
@@ -3279,10 +3279,10 @@ def test_ss_lastk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_rowwise("last", 3)
+    B = A.ss.selectk("last", 3)
     assert B.isequal(A)
 
-    B = A.ss.selectk_columnwise("last", 1)
+    B = A.ss.selectk("last", 1, order="col")
     expected = Matrix.from_coo(
         [3, 0, 6, 6, 6, 4, 1],
         [0, 1, 2, 3, 4, 5, 6],
@@ -3292,7 +3292,7 @@ def test_ss_lastk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_columnwise("last", 2)
+    B = A.ss.selectk("last", 2, order="col")
     expected = Matrix.from_coo(
         [3, 0, 5, 6, 0, 6, 1, 6, 2, 4, 1],
         [0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
@@ -3302,7 +3302,7 @@ def test_ss_lastk(A):
     )
     assert B.isequal(expected)
 
-    B = A.ss.selectk_columnwise("last", 3)
+    B = A.ss.selectk("last", 3, order="col")
     assert B.isequal(A)
 
 
@@ -3318,23 +3318,23 @@ def test_ss_compactify(A, do_iso):
     orig_cols = [1, 3, 4, 6, 5, 0, 2, 5, 2, 2, 3, 4]
 
     def check(A, expected, *args, stop=0, **kwargs):
-        B = A.ss.compactify_rowwise(*args, **kwargs)
+        B = A.ss.compactify(*args, **kwargs)
         assert B.isequal(expected)
         for n in reversed(range(stop, 4)):
             expected = expected[:, :n].new()
-            B = A.ss.compactify_rowwise(*args, ncols=n, **kwargs)
+            B = A.ss.compactify(*args, n, **kwargs)
             assert B.isequal(expected)
 
     def reverse(A):
-        return A[:, ::-1].new().ss.compactify_rowwise("first", A.ncols)
+        return A[:, ::-1].new().ss.compactify("first", A.ncols)
 
     def check_reverse(A, expected, *args, stop=0, **kwargs):
-        B = A.ss.compactify_rowwise(*args, reverse=True, **kwargs)
+        B = A.ss.compactify(*args, reverse=True, **kwargs)
         C = reverse(expected)
         assert B.isequal(C)
         for n in reversed(range(stop, 4)):
             C = reverse(expected[:, :n].new())
-            B = A.ss.compactify_rowwise(*args, ncols=n, reverse=True, **kwargs)
+            B = A.ss.compactify(*args, n, reverse=True, **kwargs)
             assert B.isequal(C)
 
     expected = Matrix.from_coo(
@@ -3388,7 +3388,7 @@ def test_ss_compactify(A, do_iso):
 
     def compare(A, expected, isequal=True, **kwargs):
         for _ in range(1000):
-            B = A.ss.compactify_rowwise("random", **kwargs)
+            B = A.ss.compactify("random", **kwargs)
             if B.isequal(expected) == isequal:
                 break
         else:
@@ -3398,39 +3398,37 @@ def test_ss_compactify(A, do_iso):
         compare(A, A[:, ::-1].new())
 
     for asindex in [False, True]:
-        compare(A, A.ss.compactify_rowwise("first", asindex=asindex), asindex=asindex)
-        compare(A, A.ss.compactify_rowwise("first", 3, asindex=asindex), ncols=3, asindex=asindex)
-        compare(A, A.ss.compactify_rowwise("first", 2, asindex=asindex), ncols=2, asindex=asindex)
+        compare(A, A.ss.compactify("first", asindex=asindex), asindex=asindex)
+        compare(A, A.ss.compactify("first", 3, asindex=asindex), k=3, asindex=asindex)
+        compare(A, A.ss.compactify("first", 2, asindex=asindex), k=2, asindex=asindex)
         compare(
             A,
-            A.ss.compactify_rowwise("first", 2, asindex=asindex),
-            ncols=2,
+            A.ss.compactify("first", 2, asindex=asindex),
+            k=2,
             asindex=asindex,
             isequal=do_iso,
         )
-        compare(A, A.ss.compactify_rowwise("first", 1, asindex=asindex), ncols=1, asindex=asindex)
+        compare(A, A.ss.compactify("first", 1, asindex=asindex), k=1, asindex=asindex)
         compare(
             A,
-            A.ss.compactify_rowwise("first", 1, asindex=asindex),
-            ncols=1,
+            A.ss.compactify("first", 1, asindex=asindex),
+            k=1,
             asindex=asindex,
             isequal=do_iso,
         )
-        compare(A, A.ss.compactify_rowwise("last", 1, asindex=asindex), ncols=1, asindex=asindex)
-        compare(
-            A, A.ss.compactify_rowwise("smallest", 1, asindex=asindex), ncols=1, asindex=asindex
-        )
-        compare(A, A.ss.compactify_rowwise("largest", 1, asindex=asindex), ncols=1, asindex=asindex)
-        compare(A, A.ss.compactify_rowwise("first", 0, asindex=asindex), ncols=0, asindex=asindex)
+        compare(A, A.ss.compactify("last", 1, asindex=asindex), k=1, asindex=asindex)
+        compare(A, A.ss.compactify("smallest", 1, asindex=asindex), k=1, asindex=asindex)
+        compare(A, A.ss.compactify("largest", 1, asindex=asindex), k=1, asindex=asindex)
+        compare(A, A.ss.compactify("first", 0, asindex=asindex), k=0, asindex=asindex)
 
-    B = A.ss.compactify_columnwise("first", nrows=1)
+    B = A.ss.compactify("first", k=1, order="col")
     expected = Matrix.from_coo(
         [0, 0, 0, 0, 0, 0, 0],
         [0, 1, 2, 3, 4, 5, 6],
         1 if do_iso else [3, 2, 3, 3, 8, 1, 4],
     )
     assert B.isequal(expected)
-    B = A.ss.compactify_columnwise("last", nrows=1, asindex=True)
+    B = A.ss.compactify("last", k=1, asindex=True, order="col")
     expected = Matrix.from_coo(
         [0, 0, 0, 0, 0, 0, 0],
         [0, 1, 2, 3, 4, 5, 6],
@@ -3438,7 +3436,7 @@ def test_ss_compactify(A, do_iso):
     )
     assert B.isequal(expected)
     with pytest.raises(ValueError):
-        A.ss.compactify_rowwise("bad_how")
+        A.ss.compactify("bad_how")
 
 
 def test_deprecated(A):
@@ -3448,6 +3446,18 @@ def test_deprecated(A):
             A.ss.diag(v)
         with pytest.warns(DeprecationWarning):
             v.ss.diag(A)
+        with pytest.warns(DeprecationWarning):
+            A.ss.compactify_rowwise()
+        with pytest.warns(DeprecationWarning):
+            A.ss.compactify_columnwise()
+        with pytest.warns(DeprecationWarning):
+            A.ss.scan_rowwise()
+        with pytest.warns(DeprecationWarning):
+            A.ss.scan_columnwise()
+        with pytest.warns(DeprecationWarning):
+            A.ss.selectk_rowwise("first", 3)
+        with pytest.warns(DeprecationWarning):
+            A.ss.selectk_columnwise("first", 3)
     with pytest.warns(DeprecationWarning):
         Matrix.new(int)
     with pytest.warns(DeprecationWarning):

--- a/graphblas/tests/test_prefix_scan.py
+++ b/graphblas/tests/test_prefix_scan.py
@@ -33,10 +33,10 @@ def test_scan_matrix(method, length, do_random):
         expected = A.cumsum(axis=1)
 
     if method == "scan_rowwise":
-        R = M.ss.scan_rowwise()
+        R = M.ss.scan()
     else:
         M = M.T.new(name="A")
-        R = M.ss.scan_columnwise(binary.plus).T.new()
+        R = M.ss.scan(binary.plus, order="col").T.new()
 
     result = gb.io.to_numpy(R)
     try:

--- a/notebooks/HPEC2022.ipynb
+++ b/notebooks/HPEC2022.ipynb
@@ -2065,7 +2065,7 @@
     }
    ],
    "source": [
-    "B.ss.compactify_rowwise()"
+    "B.ss.compactify()"
    ]
   },
   {
@@ -2260,7 +2260,7 @@
     }
    ],
    "source": [
-    "B.ss.compactify_rowwise(how=\"last\", ncols=1)"
+    "B.ss.compactify(how=\"last\", ncols=1)"
    ]
   },
   {
@@ -2455,7 +2455,7 @@
     }
    ],
    "source": [
-    "B.ss.compactify_rowwise(how=\"random\", ncols=1)"
+    "B.ss.compactify(how=\"random\", ncols=1)"
    ]
   },
   {
@@ -2674,7 +2674,7 @@
     }
    ],
    "source": [
-    "B.ss.selectk_rowwise(\"first\", 1)"
+    "B.ss.selectk(\"first\", 1)"
    ]
   },
   {
@@ -2893,7 +2893,7 @@
     }
    ],
    "source": [
-    "B.ss.selectk_rowwise(\"last\", 1)"
+    "B.ss.selectk(\"last\", 1)"
    ]
   },
   {
@@ -3112,7 +3112,7 @@
     }
    ],
    "source": [
-    "B.ss.selectk_rowwise(\"random\", 1)"
+    "B.ss.selectk(\"random\", 1)"
    ]
   },
   {


### PR DESCRIPTION
Use e.g. `ss.scan(order="columnwise")` instead.

This follows up from the discussion in https://github.com/python-graphblas/python-graphblas/pull/333