### PR TITLE
Add vanilla recipe for slicing

### DIFF
--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -99,7 +99,7 @@ def init(backend="suitesparse", blocking=False):
 
     Parameters
     ----------
-    backend : str, one of {"suitesparse"}
+    backend : str, one of {"suitesparse", "suitesparse-vanilla"}
     blocking : bool
         Whether to call GrB_init with GrB_BLOCKING or GrB_NONBLOCKING
 
@@ -159,9 +159,12 @@ def _init(backend_arg, blocking, automatic=False):
                 if callable(val) and key.startswith("GxB") or "FC32" in key or "FC64" in key:
                     continue
                 setattr(lib, key, getattr(orig_lib, key))
-
+            for key in {"GxB_BACKWARDS", "GxB_STRIDE"}:
+                delattr(lib, key)
     else:
-        raise ValueError(f'Bad backend name.  Must be "suitesparse".  Got: {backend}')
+        raise ValueError(
+            f'Bad backend name.  Must be "suitesparse" or "suitesparse-vanilla".  Got: {backend}'
+        )
     _init_params = passed_params
 
     from . import core

--- a/graphblas/core/expr.py
+++ b/graphblas/core/expr.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from .. import backend
 from ..dtypes import _INDEX
 from . import lib, utils
 from .utils import _CArray, output_type
@@ -57,18 +58,21 @@ class AxisIndex:
             return self.index.value
         if self.index is _ALL_INDICES:
             return slice(None)
-        from .slice import gxb_backwards, gxb_range, gxb_stride
+        if backend != "suitesparse":
+            return self.index.array
 
-        if self.cscalar is gxb_backwards:
+        from .slice import _gxb_backwards, _gxb_range, _gxb_stride
+
+        if self.cscalar is _gxb_backwards:
             start, stop, step = self.index.array.tolist()
             size = self.dimsize
             stop -= size + 1
             step = -step
-        elif self.cscalar is gxb_range:
+        elif self.cscalar is _gxb_range:
             start, stop = self.index.array.tolist()
             step = None
             stop += 1
-        elif self.cscalar is gxb_stride:
+        elif self.cscalar is _gxb_stride:
             start, stop, step = self.index.array.tolist()
             stop += 1
         else:

--- a/graphblas/core/slice.py
+++ b/graphblas/core/slice.py
@@ -1,14 +1,20 @@
+import numpy as np
+
+from .. import backend
 from ..dtypes import _INDEX
 from . import lib
 from .expr import _ALL_INDICES, AxisIndex
 from .scalar import Scalar, _as_scalar
 from .utils import _CArray
 
-gxb_range = Scalar.from_value(lib.GxB_RANGE, dtype=_INDEX, name="GxB_RANGE", is_cscalar=True)
-gxb_stride = Scalar.from_value(lib.GxB_STRIDE, dtype=_INDEX, name="GxB_STRIDE", is_cscalar=True)
-gxb_backwards = Scalar.from_value(
-    lib.GxB_BACKWARDS, dtype=_INDEX, name="GxB_BACKWARDS", is_cscalar=True
-)
+if backend == "suitesparse":
+    _gxb_range = Scalar.from_value(lib.GxB_RANGE, dtype=_INDEX, name="GxB_RANGE", is_cscalar=True)
+    _gxb_stride = Scalar.from_value(
+        lib.GxB_STRIDE, dtype=_INDEX, name="GxB_STRIDE", is_cscalar=True
+    )
+    _gxb_backwards = Scalar.from_value(
+        lib.GxB_BACKWARDS, dtype=_INDEX, name="GxB_BACKWARDS", is_cscalar=True
+    )
 
 
 def slice_to_index(index, size):
@@ -17,18 +23,27 @@ def slice_to_index(index, size):
     if length == size and step == 1:
         # [:] means all indices; use special GrB_ALL indicator
         return AxisIndex(size, _ALL_INDICES, _as_scalar(size, _INDEX, is_cscalar=True), size)
+    if backend != "suitesparse":
+        # Danger zone: compute all the indices
+        return AxisIndex(
+            length,
+            _CArray(np.arange(start, stop, step, dtype=np.uint64)),
+            _as_scalar(length, _INDEX, is_cscalar=True),
+            size,
+        )
+
     # SS, SuiteSparse-specific: slicing.
     # For non-SuiteSparse, do: index = list(range(size)[index])
     # SuiteSparse indexing is inclusive for both start and stop, and unsigned.
     if step < 0:
         if start < 0:
             start = stop = 0  # Must be empty
-        return AxisIndex(length, _CArray([start, stop + 1, -step]), gxb_backwards, size)
+        return AxisIndex(length, _CArray([start, stop + 1, -step]), _gxb_backwards, size)
     if stop > 0:
         stop -= 1
     elif start == 0:
         # [0:0] slice should be empty, so change to [1:0]
         start += 1
     if step == 1:
-        return AxisIndex(length, _CArray([start, stop]), gxb_range, size)
-    return AxisIndex(length, _CArray([start, stop, step]), gxb_stride, size)
+        return AxisIndex(length, _CArray([start, stop]), _gxb_range, size)
+    return AxisIndex(length, _CArray([start, stop, step]), _gxb_stride, size)


### PR DESCRIPTION
If backend is not suitesparse, this expands Python slices into numpy array of indices.

This continues #307 and gets us one step closer to supporting other backends (#172).