### PR TITLE
Remove deprecated `Matrix.ss.diag` and `Vector.ss.diag`

### DIFF
--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -244,20 +244,6 @@ class ss:
             return "columnwise"
         return "rowwise"
 
-    def diag(self, vector, k=0):
-        """
-        GxB_Matrix_diag
-
-        **This function is deprecated.  Use ``Vector.diag`` or ``Matrix.ss.build_diag`` instead.**
-
-        """
-        warnings.warn(
-            "`Matrix.ss.diag` is deprecated; "
-            "please use `Vector.diag` or `Matrix.ss.build_diag` instead",
-            DeprecationWarning,
-        )
-        self.build_diag(vector, k)
-
     def build_diag(self, vector, k=0):
         """
         GxB_Matrix_diag

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 
 import numpy as np
 from numba import njit
@@ -146,20 +145,6 @@ class ss:
         else:  # pragma: no cover (sanity)
             raise NotImplementedError(f"Unknown sparsity status: {sparsity_status}")
         return format
-
-    def diag(self, matrix, k=0):
-        """
-        GxB_Vector_diag
-
-        **This function is deprecated.  Use ``Matrix.diag`` or ``Vector.ss.build_diag`` instead.**
-
-        """
-        warnings.warn(
-            "`Vector.ss.diag` is deprecated; "
-            "please use `Matrix.diag` or `Vector.ss.build_diag` instead",
-            DeprecationWarning,
-        )
-        self.build_diag(matrix, k)
 
     def build_diag(self, matrix, k=0):
         """

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3441,12 +3441,7 @@ def test_ss_compactify(A, do_iso):
 
 
 def test_deprecated(A):
-    v = A.diag()
     if suitesparse:
-        with pytest.warns(DeprecationWarning):
-            A.ss.diag(v)
-        with pytest.warns(DeprecationWarning):
-            v.ss.diag(A)
         with pytest.warns(DeprecationWarning):
             A.ss.compactify_rowwise()
         with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
These have been deprecated since 2022-04-04 (see #330)