### PR TITLE
Remove the fully deprecated `.mask` property of `Mask`

### DIFF
--- a/graphblas/core/mask.py
+++ b/graphblas/core/mask.py
@@ -33,14 +33,6 @@ class Mask:
     def _carg(self):
         return self.parent.gb_obj[0]
 
-    @property
-    def mask(self):
-        warnings.warn(
-            "`mask.mask` is deprecated; please use `mask.parent` instead.",
-            DeprecationWarning,
-        )
-        return self.parent
-
     def new(self, dtype=None, *, complement=False, mask=None, name=None):
         """Return a new object with True values determined by the mask(s).
 

--- a/graphblas/core/mask.py
+++ b/graphblas/core/mask.py
@@ -1,5 +1,3 @@
-import warnings
-
 from .. import backend, monoid
 from ..binary import land, lor, pair
 from ..dtypes import BOOL

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -3466,8 +3466,6 @@ def test_deprecated(A):
     with pytest.warns(DeprecationWarning):
         Scalar.new(int)
     with pytest.warns(DeprecationWarning):
-        A.S.mask
-    with pytest.warns(DeprecationWarning):
         binary.plus(A | A, require_monoid=True)
     with pytest.warns(DeprecationWarning):
         A.to_values()


### PR DESCRIPTION
This resolves deprecation of `.mask` mentioned in https://github.com/python-graphblas/python-graphblas/issues/330.