### PR TITLE
Add extra (and not by default) dev dependencies to environment.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: autoflake
         args: [--in-place]
   - repo: https://github.com/pycqa/isort
-    rev: v5.11.3
+    rev: 5.11.4
     hooks:
       - id: isort
         language_version: python3

--- a/environment.yml
+++ b/environment.yml
@@ -52,6 +52,7 @@ dependencies:
     # - codespell
     # - cython
     # - cytoolz
+    # - distributed
     # - flake8
     # - flake8-bugbear
     # - flake8-comprehensions
@@ -78,6 +79,7 @@ dependencies:
     # - pygraphviz
     # - pytest-runner
     # - pytest-xdist
+    # - python-graphviz
     # - python-igraph
     # - python-louvain
     # - pyupgrade
@@ -85,3 +87,4 @@ dependencies:
     # - snakeviz
     # - sympy
     # - yesqa
+    # - zarr

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 #   $ conda env create -f environment.yml
 #   $ conda activate graphblas-dev
 #
-# Or use mamba instead of conda.
+# Or use mamba instead of conda. Creating the environment may take several minutes.
 #
 # pre-commit should be set up once after the repo is cloned (see .pre-commit-config.yaml).
 # In the `graphblas-dev` environment, run:
@@ -36,8 +36,8 @@ dependencies:
     - pytest-cov
     # For debugging
     - icecream
-    - ipython
     - ipykernel
+    - ipython
     # For type annotations
     - mypy
     # For building docs
@@ -45,3 +45,43 @@ dependencies:
     - numpydoc
     - pydata-sphinx-theme
     - sphinx-panels
+    # EXTRA (optional; uncomment as desired)
+    # - autoflake
+    # - black
+    # - black-jupyter
+    # - codespell
+    # - cython
+    # - cytoolz
+    # - flake8
+    # - flake8-bugbear
+    # - flake8-comprehensions
+    # - gcc
+    # - gh
+    # - graph-tool
+    # - xorg-libxcursor  # for graph-tool
+    # - grayskull
+    # - h5py
+    # - hiveplot
+    # - igraph
+    # - ipycytoscape
+    # - isort
+    # - jupyter
+    # - jupyterlab
+    # - line_profiler
+    # - lxml
+    # - memory_profiler
+    # - netcdf4
+    # - networkit
+    # - nxviz
+    # - pycodestyle
+    # - pydot
+    # - pygraphviz
+    # - pytest-runner
+    # - pytest-xdist
+    # - python-igraph
+    # - python-louvain
+    # - pyupgrade
+    # - scalene
+    # - snakeviz
+    # - sympy
+    # - yesqa


### PR DESCRIPTION
These dependencies aren't typically needed, so I don't want to always install them. But, I want a convenient way to to make environments with some or all of these dependencies, so let's add them commented out by default. I would say these are for advanced users/devs, so I don't want to bother with breaking these up into logical groups (somebody else is welcome to do so). Presumably, if you uncomment an extra dependency to install, you should know why you want it.

@jim22k @SultanOrazbayev is there anything else you would want in one of your dev environments? I think having this section lets us be more accommodating without being overly scrutinizing.

Happy to answer questions for why I added what I did.