### PR TITLE
Remove use of `vararg` for increased compatibility

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -70,7 +70,7 @@ jobs:
           if [[ ${{ matrix.cfg.sourcetype }} == "wheel" ]]; then
               pip install suitesparse-graphblas
           else
-              mamba install -c conda-forge "graphblas>=7.3.0"
+              mamba install -c conda-forge "graphblas>=7.4.0"
           fi
           if [[ ${{ matrix.cfg.sourcetype }} == "source" ]]; then
               pip install --no-binary=all suitesparse-graphblas

--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -1,8 +1,6 @@
 import sys as _sys
 from importlib import import_module as _import_module
 
-from suitesparse_graphblas import vararg as _vararg
-
 from ._version import get_versions
 
 
@@ -132,8 +130,8 @@ def _init(backend_arg, blocking, automatic=False):
         from suitesparse_graphblas import ffi, initialize, is_initialized, lib
 
         if is_initialized():
-            mode = ffi.new("GrB_Mode*")
-            assert lib.GxB_Global_Option_get(lib.GxB_MODE, _vararg(mode)) == 0
+            mode = ffi.new("int32_t*")
+            assert lib.GxB_Global_Option_get_INT32(lib.GxB_MODE, mode) == 0
             is_blocking = mode[0] == lib.GrB_BLOCKING
             if blocking is None:
                 passed_params["blocking"] = is_blocking

--- a/graphblas/core/ss/config.py
+++ b/graphblas/core/ss/config.py
@@ -63,13 +63,14 @@ class BaseConfig(MutableMapping):
         is_bool = ctype == "bool"
         if ctype in self._int32_ctypes:
             ctype = "int32_t"
-            get_function = getattr(lib, f"{self._get_function}_INT32")
+            get_function_name = f"{self._get_function}_INT32"
         elif ctype.startswith("int64_t"):
-            get_function = getattr(lib, f"{self._get_function}_INT64")
+            get_function_name = f"{self._get_function}_INT64"
         elif ctype.startswith("double"):
-            get_function = getattr(lib, f"{self._get_function}_FP64")
+            get_function_name = f"{self._get_function}_FP64"
         else:  # pragma: no cover (sanity)
             raise ValueError(ctype)
+        get_function = getattr(lib, get_function_name)
         is_array = "[" in ctype
         val_ptr = ffi.new(ctype if is_array else f"{ctype}*")
         if self._parent is None:
@@ -104,15 +105,16 @@ class BaseConfig(MutableMapping):
         key_obj, ctype = self._options[key]
         if ctype in self._int32_ctypes:
             ctype = "int32_t"
-            set_function = getattr(lib, f"{self._set_function}_INT32")
+            set_function_name = f"{self._set_function}_INT32"
         elif ctype == "double":
-            set_function = getattr(lib, f"{self._set_function}_FP64")
+            set_function_name = f"{self._set_function}_FP64"
         elif ctype.startswith("int64_t["):
-            set_function = getattr(lib, f"{self._set_function}_INT64_ARRAY")
+            set_function_name = f"{self._set_function}_INT64_ARRAY"
         elif ctype.startswith("double["):
-            set_function = getattr(lib, f"{self._set_function}_FP64_ARRAY")
+            set_function_name = f"{self._set_function}_FP64_ARRAY"
         else:  # pragma: no cover (sanity)
             raise ValueError(ctype)
+        set_function = getattr(lib, set_function_name)
         if val is None:
             pass
         elif key in self._enumerations:

--- a/graphblas/core/ss/config.py
+++ b/graphblas/core/ss/config.py
@@ -1,8 +1,6 @@
 from collections.abc import MutableMapping
 from numbers import Integral
 
-from suitesparse_graphblas import vararg
-
 from ...dtypes import lookup_dtype
 from ...exceptions import _error_code_lookup, check_status
 from .. import NULL, ffi, lib
@@ -21,10 +19,13 @@ class BaseConfig(MutableMapping):
     _bitwise = {}
     _enumerations = {}
     _read_only = set()
-    _set_ctypes = {
-        "GxB_Format_Value": "int",
-        "GrB_Desc_Value": "int",
-        "bool": "int",
+    _int32_ctypes = {
+        "bool",
+        "int",
+        "int32_t",
+        "GrB_Desc_Value",
+        "GrB_Mode",
+        "GxB_Format_Value",
     }
 
     def __init__(self, parent=None):
@@ -59,12 +60,22 @@ class BaseConfig(MutableMapping):
         if key not in self._options:
             raise KeyError(key)
         key_obj, ctype = self._options[key]
+        is_bool = ctype == "bool"
+        if ctype in self._int32_ctypes:
+            ctype = "int32_t"
+            get_function = getattr(lib, f"{self._get_function}_INT32")
+        elif ctype.startswith("int64_t"):
+            get_function = getattr(lib, f"{self._get_function}_INT64")
+        elif ctype.startswith("double"):
+            get_function = getattr(lib, f"{self._get_function}_FP64")
+        else:  # pragma: no cover (sanity)
+            raise ValueError(ctype)
         is_array = "[" in ctype
         val_ptr = ffi.new(ctype if is_array else f"{ctype}*")
         if self._parent is None:
-            info = self._get_function(key_obj, vararg(val_ptr))
+            info = get_function(key_obj, val_ptr)
         else:
-            info = self._get_function(self._parent._carg, key_obj, vararg(val_ptr))
+            info = get_function(self._parent._carg, key_obj, val_ptr)
         if info == lib.GrB_SUCCESS:  # pragma: no branch (safety)
             if is_array:
                 return list(val_ptr)
@@ -79,6 +90,8 @@ class BaseConfig(MutableMapping):
                     if isinstance(k, str) and val & v and bin(v).count("1") == 1:
                         rv.add(k)
                 return rv
+            if is_bool:
+                return bool(val_ptr[0])
             return val_ptr[0]
         raise _error_code_lookup[info](f"Failed to get info for {key!r}")  # pragma: no cover
 
@@ -89,7 +102,17 @@ class BaseConfig(MutableMapping):
         if key in self._read_only:
             raise ValueError(f"Config option {key!r} is read-only")
         key_obj, ctype = self._options[key]
-        ctype = self._set_ctypes.get(ctype, ctype)
+        if ctype in self._int32_ctypes:
+            ctype = "int32_t"
+            set_function = getattr(lib, f"{self._set_function}_INT32")
+        elif ctype == "double":
+            set_function = getattr(lib, f"{self._set_function}_FP64")
+        elif ctype.startswith("int64_t"):
+            set_function = getattr(lib, f"{self._set_function}_INT64_ARRAY")
+        elif ctype.startswith("double"):
+            set_function = getattr(lib, f"{self._set_function}_FP64_ARRAY")
+        else:  # pragma: no cover (sanity)
+            raise ValueError(ctype)
         if val is None:
             pass
         elif key in self._enumerations:
@@ -132,9 +155,9 @@ class BaseConfig(MutableMapping):
         else:
             val_obj = ffi.cast(ctype, val)
         if self._parent is None:
-            info = self._set_function(key_obj, vararg(val_obj))
+            info = set_function(key_obj, val_obj)
         else:
-            info = self._set_function(self._parent._carg, key_obj, vararg(val_obj))
+            info = set_function(self._parent._carg, key_obj, val_obj)
         if info != lib.GrB_SUCCESS:
             if self._parent is not None:  # pragma: no branch (safety)
                 check_status(info, self._parent)

--- a/graphblas/core/ss/config.py
+++ b/graphblas/core/ss/config.py
@@ -107,9 +107,9 @@ class BaseConfig(MutableMapping):
             set_function = getattr(lib, f"{self._set_function}_INT32")
         elif ctype == "double":
             set_function = getattr(lib, f"{self._set_function}_FP64")
-        elif ctype.startswith("int64_t"):
+        elif ctype.startswith("int64_t["):
             set_function = getattr(lib, f"{self._set_function}_INT64_ARRAY")
-        elif ctype.startswith("double"):
+        elif ctype.startswith("double["):
             set_function = getattr(lib, f"{self._set_function}_FP64_ARRAY")
         else:  # pragma: no cover (sanity)
             raise ValueError(ctype)

--- a/graphblas/core/ss/descriptor.py
+++ b/graphblas/core/ss/descriptor.py
@@ -1,5 +1,3 @@
-from suitesparse_graphblas import vararg
-
 from ...exceptions import check_status, check_status_carg
 from .. import ffi, lib
 from ..descriptor import Descriptor
@@ -18,8 +16,8 @@ _str_to_compression = {
 
 # It would be great if we could make Descriptor class more like this
 class _DescriptorConfig(BaseConfig):
-    _get_function = lib.GxB_Desc_get
-    _set_function = lib.GxB_Desc_set
+    _get_function = "GxB_Desc_get"
+    _set_function = "GxB_Desc_set"
     _options = {
         # GrB
         "output_replace": (lib.GrB_OUTP, "GrB_Desc_Value"),
@@ -192,10 +190,10 @@ def _set_compression(desc, compression, level):
             )
         comp += level
     check_status(
-        lib.GxB_Desc_set(
+        lib.GxB_Desc_set_INT32(
             desc._carg,
             lib.GxB_COMPRESSION,
-            vararg(ffi.cast("int", comp)),
+            ffi.cast("int32_t", comp),
         ),
         desc,
     )

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -4,7 +4,6 @@ import warnings
 import numba
 import numpy as np
 from numba import njit
-from suitesparse_graphblas import vararg
 from suitesparse_graphblas.utils import claim_buffer, claim_buffer_2d, unclaim_buffer
 
 import graphblas as gb
@@ -133,8 +132,8 @@ class MatrixConfig(BaseConfig):
         Current sparsity format
     """
 
-    _get_function = lib.GxB_Matrix_Option_get
-    _set_function = lib.GxB_Matrix_Option_set
+    _get_function = "GxB_Matrix_Option_get"
+    _set_function = "GxB_Matrix_Option_set"
     _options = {
         "format": (lib.GxB_FORMAT, "GxB_Format_Value"),
         "hyper_switch": (lib.GxB_HYPER_SWITCH, "double"),
@@ -203,14 +202,14 @@ class ss:
     def format(self):
         # Determine current format
         parent = self._parent
-        format_ptr = ffi_new("GxB_Option_Field*")
-        sparsity_ptr = ffi_new("GxB_Option_Field*")
+        format_ptr = ffi_new("int32_t*")
+        sparsity_ptr = ffi_new("int32_t*")
         check_status(
-            lib.GxB_Matrix_Option_get(parent._carg, lib.GxB_FORMAT, vararg(format_ptr)),
+            lib.GxB_Matrix_Option_get_INT32(parent._carg, lib.GxB_FORMAT, format_ptr),
             parent,
         )
         check_status(
-            lib.GxB_Matrix_Option_get(parent._carg, lib.GxB_SPARSITY_STATUS, vararg(sparsity_ptr)),
+            lib.GxB_Matrix_Option_get_INT32(parent._carg, lib.GxB_SPARSITY_STATUS, sparsity_ptr),
             parent,
         )
         sparsity_status = sparsity_ptr[0]
@@ -233,9 +232,9 @@ class ss:
     @property
     def orientation(self):
         parent = self._parent
-        format_ptr = ffi_new("GxB_Option_Field*")
+        format_ptr = ffi_new("int32_t*")
         check_status(
-            lib.GxB_Matrix_Option_get(parent._carg, lib.GxB_FORMAT, vararg(format_ptr)),
+            lib.GxB_Matrix_Option_get_INT32(parent._carg, lib.GxB_FORMAT, format_ptr),
             parent,
         )
         if format_ptr[0] == lib.GxB_BY_COL:

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -2,7 +2,6 @@ import itertools
 
 import numpy as np
 from numba import njit
-from suitesparse_graphblas import vararg
 from suitesparse_graphblas.utils import claim_buffer, unclaim_buffer
 
 import graphblas as gb
@@ -63,8 +62,8 @@ class VectorConfig(BaseConfig):
         Current sparsity format
     """
 
-    _get_function = lib.GxB_Vector_Option_get
-    _set_function = lib.GxB_Vector_Option_set
+    _get_function = "GxB_Vector_Option_get"
+    _set_function = "GxB_Vector_Option_set"
     _options = {
         "bitmap_switch": (lib.GxB_BITMAP_SWITCH, "double"),
         "sparsity_control": (lib.GxB_SPARSITY_CONTROL, "int"),
@@ -129,9 +128,9 @@ class ss:
     @property
     def format(self):
         parent = self._parent
-        sparsity_ptr = ffi_new("GxB_Option_Field*")
+        sparsity_ptr = ffi_new("int32_t*")
         check_status(
-            lib.GxB_Vector_Option_get(parent._carg, lib.GxB_SPARSITY_STATUS, vararg(sparsity_ptr)),
+            lib.GxB_Vector_Option_get_INT32(parent._carg, lib.GxB_SPARSITY_STATUS, sparsity_ptr),
             parent,
         )
         sparsity_status = sparsity_ptr[0]

--- a/graphblas/ss/_core.py
+++ b/graphblas/ss/_core.py
@@ -1,7 +1,5 @@
 from collections.abc import Mapping
 
-from suitesparse_graphblas import vararg
-
 from ..core import ffi, lib
 from ..core.base import _expect_type
 from ..core.matrix import Matrix, TransposedMatrix
@@ -132,8 +130,8 @@ class GlobalConfig(BaseConfig):
     Setting values to None restores the default value for most configurations.
     """
 
-    _get_function = lib.GxB_Global_Option_get
-    _set_function = lib.GxB_Global_Option_set
+    _get_function = "GxB_Global_Option_get"
+    _set_function = "GxB_Global_Option_set"
     _null_valid = {"bitmap_switch"}
     _options = {
         # Matrix/Vector format
@@ -210,28 +208,28 @@ class About(Mapping):
     def __getitem__(self, key):
         key = key.lower()
         if key in self._mode_options:
-            val_ptr = ffi.new("GrB_Mode*")
-            info = lib.GxB_Global_Option_get(self._mode_options[key], vararg(val_ptr))
+            val_ptr = ffi.new("int32_t*")
+            info = lib.GxB_Global_Option_get_INT32(self._mode_options[key], val_ptr)
             if info == lib.GrB_SUCCESS:  # pragma: no branch (safety)
                 val = val_ptr[0]
                 if val not in self._modes:  # pragma: no cover (sanity)
                     raise ValueError(f"Unknown mode: {val}")
                 return self._modes[val]
         elif key in self._int3_options:
-            val_ptr = ffi.new("int[3]")
-            info = lib.GxB_Global_Option_get(self._int3_options[key], vararg(val_ptr))
+            val_ptr = ffi.new("int32_t[3]")
+            info = lib.GxB_Global_Option_get_INT32(self._int3_options[key], val_ptr)
             if info == lib.GrB_SUCCESS:  # pragma: no branch (safety)
                 return (val_ptr[0], val_ptr[1], val_ptr[2])
         elif key in self._str_options:
             val_ptr = ffi.new("char**")
-            info = lib.GxB_Global_Option_get(self._str_options[key], vararg(val_ptr))
+            info = lib.GxB_Global_Option_get_CHAR(self._str_options[key], val_ptr)
             if info == lib.GrB_SUCCESS:  # pragma: no branch (safety)
                 return ffi.string(val_ptr[0]).decode()
         elif key in self._bool_options:
-            val_ptr = ffi.new("bool*")
-            info = lib.GxB_Global_Option_get(self._bool_options[key], vararg(val_ptr))
+            val_ptr = ffi.new("int32_t*")
+            info = lib.GxB_Global_Option_get_INT32(self._bool_options[key], val_ptr)
             if info == lib.GrB_SUCCESS:  # pragma: no branch (safety)
-                return val_ptr[0]
+                return bool(val_ptr[0])
         else:
             raise KeyError(key)
         raise _error_code_lookup[info](f"Failed to get info for {key}")  # pragma: no cover (safety)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/python-graphblas/python-graphblas",
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=["suitesparse-graphblas >=7.3.2.0, <7.4", "numba", "donfig", "pyyaml"],
+    install_requires=["suitesparse-graphblas >=7.4.0.0, <7.5", "numba", "donfig", "pyyaml"],
     extras_require=extras_require,
     include_package_data=True,
     license="Apache License 2.0",


### PR DESCRIPTION
I did the easy thing and mapped existing ctypes to `int32_t` when appropriate rather than update data structures on e.g. `MatrixConfig`.

Removing `vararg` should allow `python-graphblas` to be used across more architectures without worry.

I want to get this merged and then do a release.

Reviews welcome, but not necessary imho.