### PR TITLE
Give informative errors with bad descriptor options

### DIFF
--- a/graphblas/core/ss/descriptor.py
+++ b/graphblas/core/ss/descriptor.py
@@ -162,8 +162,25 @@ def get_descriptor(**opts):
         try:
             config[key] = val
         except KeyError:
+            if key in config._enumerations:
+                values = {x for x in config._enumerations[key] if isinstance(x, (bool, str))}
+                raise ValueError(
+                    f"Invalid value for {key!r} descriptor option: {val!r}. "
+                    f"Must be one of {', '.join(repr(x) for x in sorted(values))}"
+                ) from None
+            if key in config:  # pragma: no cover (safety)
+                raise ValueError(f"Invalid value for {key!r} descriptor option") from None
+            valid = set(config) | {"compression", "compression_level"}
+            valid -= {
+                "mask_complement",
+                "mask_structure",
+                "output_replace",
+                "transpose_first",
+                "transpose_second",
+            }
             raise ValueError(
-                f"Descriptor option {key!r} not understood with suitesparse backend"
+                f"Descriptor option {key!r} not understood with suitesparse backend. "
+                f"Valid options: {', '.join(sorted(valid))}"
             ) from None
     return desc
 

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -4109,11 +4109,11 @@ def test_ss_descriptors(A):
         assert C1.isequal(C2)
         A(nthreads=4, axb_method="dot", sort=True) << A @ A
         assert A.isequal(C2)
-        with pytest.raises(ValueError, match="escriptor"):
+        # Bad option should show list of valid options
+        with pytest.raises(ValueError, match="nthreads"):
             C1(bad_opt=True) << A
         with pytest.raises(ValueError, match="Duplicate descriptor"):
             (A @ A).new(nthreads=4, Nthreads=5)
-
         with pytest.raises(ValueError, match="escriptor"):
             A[0, 0].new(bad_opt=True)
         A[0, 0].new(nthreads=4)  # ignored, but okay
@@ -4134,6 +4134,11 @@ def test_ss_descriptors(A):
         with pytest.raises(ValueError, match="escriptor"):
             expr.new(bad_opt=True)
         expr.new(nthreads=4)  # ignored, but okay
+        # These show the valid options
+        with pytest.raises(ValueError, match="False, True"):
+            A(sort="hi") << A
+        with pytest.raises(ValueError, match="saxpy"):
+            A(axb_method="bad") << A @ A
     else:
         with pytest.raises(ValueError, match="escriptor"):
             (A @ A).new(nthreads=4, axb_method="dot", sort=True)


### PR DESCRIPTION
Show list of valid descriptor options if bad option is given, or valid values if bad value is given. This follows our long-standing goal of trying to have informative error message to help direct users to proper usage.

This doesn't yet explain the options. It would be nice to be able to point to a docs page for information.