### PR TITLE
Make readthedocs fail if there's a warning building the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,7 @@ version: 2
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: True
 
 # Try to make build faster with mamba. See:
 # https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -34,37 +34,37 @@ Operators
 UnaryOp
 ~~~~~~~
 
-.. autoclass:: graphblas.operator.UnaryOp()
+.. autoclass:: graphblas.core.operator.UnaryOp()
     :members:
 
 BinaryOp
 ~~~~~~~~
 
-.. autoclass:: graphblas.operator.BinaryOp()
+.. autoclass:: graphblas.core.operator.BinaryOp()
     :members:
 
 Monoid
 ~~~~~~
 
-.. autoclass:: graphblas.operator.Monoid()
+.. autoclass:: graphblas.core.operator.Monoid()
     :members:
 
 Semiring
 ~~~~~~~~
 
-.. autoclass:: graphblas.operator.Semiring()
+.. autoclass:: graphblas.core.operator.Semiring()
     :members:
 
 IndexUnaryOp
 ~~~~~~~~~~~~
 
-.. autoclass:: graphblas.operator.IndexUnaryOp()
+.. autoclass:: graphblas.core.operator.IndexUnaryOp()
     :members:
 
 SelectOp
 ~~~~~~~~
 
-.. autoclass:: graphblas.operator.SelectOp()
+.. autoclass:: graphblas.core.operator.SelectOp()
     :members:
 
 

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -8,7 +8,7 @@ dependencies:
     # python-graphblas dependencies
     - donfig
     - numba
-    - python-suitesparse-graphblas>=7.3.2.0
+    - python-suitesparse-graphblas>=7.4.0.0
     - pyyaml
     # extra dependencies
     - matplotlib

--- a/docs/user_guide/udf.rst
+++ b/docs/user_guide/udf.rst
@@ -15,14 +15,13 @@ Example user-defined UnaryOp:
 .. code-block:: python
 
     from graphblas import unary
-    from graphblas.operator import UnaryOp
 
     def force_odd_func(x):
         if x % 2 == 0:
             return x + 1
         return x
 
-    UnaryOp.register_new('force_odd', force_odd_func)
+    unary.register_new('force_odd', force_odd_func)
 
     v = Vector.from_coo([0, 1, 3, 4, 5], [1, 2, 3, 8, 14])
     w = v.apply(unary.force_odd).new()

--- a/environment.yml
+++ b/environment.yml
@@ -50,6 +50,7 @@ dependencies:
     # - black
     # - black-jupyter
     # - codespell
+    # - commonmark
     # - cython
     # - cytoolz
     # - distributed
@@ -70,6 +71,7 @@ dependencies:
     # - jupyterlab
     # - line_profiler
     # - lxml
+    # - make
     # - memory_profiler
     # - netcdf4
     # - networkit

--- a/graphblas/core/matrix.py
+++ b/graphblas/core/matrix.py
@@ -2118,8 +2118,7 @@ class Matrix(BaseType):
 
         Parameters
         ----------
-        op : :class:`~graphblas.core.operator.SelectOp`or
-             :class:`~graphblas.core.operator.IndexUnaryOp`
+        op : :class:`~graphblas.core.operator.SelectOp`
             Operator to apply
         thunk :
             Scalar passed to operator

--- a/graphblas/core/vector.py
+++ b/graphblas/core/vector.py
@@ -1239,8 +1239,7 @@ class Vector(BaseType):
 
         Parameters
         ----------
-        op : :class:`~graphblas.core.operator.SelectOp` or
-             :class:`~graphblas.core.operator.IndexUnaryOp`
+        op : :class:`~graphblas.core.operator.SelectOp`
             Operator to apply
         thunk :
             Scalar passed to operator

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,3 +55,9 @@ precision = 1
 fail_under = 0
 skip_covered = True
 skip_empty = True
+
+[build_sphinx]
+all-files = 1
+source-dir = docs
+build-dir = docs/_build
+warning-is-error = 1


### PR DESCRIPTION
Also, a few fixes (one warning left to test CI).

If docs are built via `python setup.py build_sphinx`, then warnings will be treated as errors.