### PR TITLE
Change CI matrix to be [os]x[slowtask]

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -40,7 +40,7 @@ jobs:
             1
             1
             1
-      - name: RNG for source type of python-suitesparse-graphblas
+      - name: RNG for source of python-suitesparse-graphblas
         uses: ddradar/choose-random-action@v2.0.2
         id: sourcetype
         with:
@@ -52,6 +52,26 @@ jobs:
           weights: |
             1
             1
+            1
+            1
+      - name: RNG for SciPy version
+        uses: ddradar/choose-random-action@v2.0.2
+        id: spver
+        with:
+          contents: |
+            '=1.7.0'
+            '>1.7.0'
+          weights: |
+            1
+            1
+      - name: RNG for Awkward version
+        uses: ddradar/choose-random-action@v2.0.2
+        id: akver
+        with:
+          contents: |
+            '<2'
+            '>=2'
+          weights: |
             1
             1
       - name: Setup conda
@@ -71,7 +91,9 @@ jobs:
           # Don't be overwhelmed! This may look scary at a glance, but each line makes sense.
           # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
-            pandas numba scipy networkx cffi donfig pyyaml awkward \
+            pandas numba networkx cffi donfig pyyaml \
+            scipy${{ steps.spver.outputs.selected }} \
+            awkward${{ steps.akver.outputs.selected }} \
             ${{ matrix.slowtask == 'pylint' && 'black pylint' || '' }} \
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -9,7 +9,42 @@ on:
       - main
 
 jobs:
+  mapnumpy:
+    # To achieve consistent coverage, we need a little bit of correlated collaboration.
+    # Specifically, we need to make sure we run with and without `--mapnumpy` on slow tests.
+    # TODO: determine if we *also* need to run both backends on slow tests.
+    #
+    #                   linux   windows osx
+    #               +-----------------------+
+    #   A   normal  |   yes     no          |
+    #   A   bizarro |   no      yes         |
+    #   B   normal  |           no      yes |
+    #   B   bizarro |           yes     no  |
+    #   C   normal  |   no      yes         |
+    #   C   bizarro |   yes     no          |
+    #   D   normal  |           yes     no  |
+    #   D   bizarro |           no      yes |
+    #               +-----------------------+
+    runs-on: ubuntu-latest
+    outputs:
+      rng: ${{ steps.random.outputs.selected }}
+    steps:
+      - name: RNG for mapnumpy
+        uses: ddradar/choose-random-action@v2.0.2
+        id: random
+        with:
+          contents: |
+            A
+            B
+            C
+            D
+          weights: |
+            1
+            1
+            1
+            1
   build_and_test:
+    needs: mapnumpy
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -76,7 +111,7 @@ jobs:
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \
             ${{ steps.sourcetype.outputs.selected != 'wheel' && '"graphblas>=7.4.0"' || '' }} \
-            ${{ steps.sourcetype.outputs.selected == 'conda-forge' && 'python-suitesparse-graphblas' || ''}} \
+            ${{ steps.sourcetype.outputs.selected == 'conda-forge' && 'python-suitesparse-graphblas' || '' }} \
             ${{ matrix.os != 'ubuntu-latest' && '"graphblas>=7.4.0"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'wheel' && matrix.os != 'ubuntu-latest' && 'python-suitesparse-graphblas' || '' }}
       - name: Build extension module
@@ -93,6 +128,14 @@ jobs:
       - name: Unit tests
         run: |
           coverage run -m pytest --randomly -v \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
@@ -103,7 +146,15 @@ jobs:
             -e '/# pragma: to_grb/ s/is_cscalar=True/is_cscalar=False/g' \
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
           coverage run -a -m pytest --randomly -v \
-            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || ''}}
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
         if: matrix.slowtask == 'pylint'

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -54,16 +54,6 @@ jobs:
             1
             1
             1
-      - name: RNG for Awkward version
-        uses: ddradar/choose-random-action@v2.0.2
-        id: akver
-        with:
-          contents: |
-            <2
-            >=2
-          weights: |
-            1
-            1
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -81,8 +71,7 @@ jobs:
           # Don't be overwhelmed! This may look scary at a glance, but each line makes sense.
           # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
-            pandas numba scipy networkx cffi donfig pyyaml \
-            "awkward${{ steps.akver.outputs.selected }}" \
+            pandas numba scipy networkx cffi donfig pyyaml awkward \
             ${{ matrix.slowtask == 'pylint' && 'black pylint' || '' }} \
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -100,6 +100,7 @@ jobs:
         uses: ddradar/choose-random-action@v2.0.2
         id: sourcetype
         with:
+          # Set weight to 0 to skip (such as if 'upstream' is known to not work)
           contents: |
             conda-forge
             wheel
@@ -155,22 +156,23 @@ jobs:
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
           mapnumpy='--mapnumpy' ; nomapnumpy='--no-mapnumpy' ; suitesparse='--backend=suitesparse' ; vanilla='--backend=suitesparse-vanilla'
-          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)
+          args=$(
+            if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)
           echo $args
           coverage run -m pytest --randomly -v $args \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
@@ -189,22 +191,23 @@ jobs:
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
           mapnumpy='--mapnumpy' ; nomapnumpy='--no-mapnumpy' ; suitesparse='--backend=suitesparse' ; vanilla='--backend=suitesparse-vanilla'
-          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
-                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
-                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
-                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
-                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)
+          args=$(
+            if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+            if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+            if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+            if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+            if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)
           echo $args
           coverage run -a -m pytest --randomly -v $args \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -148,82 +148,59 @@ jobs:
           pip install --no-deps -e .
       - name: Unit tests
         run: |
+          A=${{ needs.rngs.outputs.mapnumpy == 'A' || '' }} ; B=${{ needs.rngs.outputs.mapnumpy == 'B' || '' }}
+          C=${{ needs.rngs.outputs.mapnumpy == 'C' || '' }} ; D=${{ needs.rngs.outputs.mapnumpy == 'D' || '' }}
+          E=${{ needs.rngs.outputs.backend == 'E' || '' }} ; F=${{ needs.rngs.outputs.backend == 'F' || '' }}
+          G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
+          normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
+          ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
+          suitesparse=--backend=suitesparse ; vanilla=--backend=suitesparse-vanilla
+          echo $A $B $C $D $E %F $G $H
           coverage run -m pytest --randomly -v \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
+            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }} \
+            $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi)
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
+          echo $A $B $C $D $E %F $G $H
           find graphblas -type f -name "*.py" -print0 | xargs -0 sed -i -s \
             -e '/# pragma: is_grbscalar/! s/is_cscalar=False/is_cscalar=True/g' \
             -e '/# pragma: is_grbscalar/! s/is_cscalar = False/is_cscalar = True/g' \
             -e '/# pragma: to_grb/ s/is_cscalar=True/is_cscalar=False/g' \
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
           coverage run -a -m pytest --randomly -v \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
-            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
-            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
+            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }} \
+            $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
+            $(if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
+            $(if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
+            $(if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
+            $(if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi)
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
         if: matrix.slowtask == 'pylint'
@@ -241,6 +218,8 @@ jobs:
           echo "from graphblas.core import base" > script.py
           coverage run -a script.py
           rm script.py
+          # Tests whose coverage depend on order of tests :/
+          coverage run -a -m pytest -x -k test_binaryop_attributes_numpy --no-mapnumpy -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
       - name: Auto-generated code check
         if: matrix.slowtask == 'pylint'
         run: |

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -150,7 +150,6 @@ jobs:
         run: |
           is_A=${{ needs.mapnumpy.outputs.rng == 'A' }}
           echo $is_A
-          echo ${{ $is_A && matrix.slowtask == 'pytest_normal' }}
           # Run tests again with Scalars being C scalars by default
           find graphblas -type f -name "*.py" -print0 | xargs -0 sed -i -s \
             -e '/# pragma: is_grbscalar/! s/is_cscalar=False/is_cscalar=True/g' \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -154,23 +154,23 @@ jobs:
           G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
-          mapnumpy=' --mapnumpy' ; nomapnumpy=' --no-mapnumpy' ; suitesparse=' --backend=suitesparse' ; vanilla=' --backend=suitesparse-vanilla'
-          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)
+          mapnumpy='--mapnumpy' ; nomapnumpy='--no-mapnumpy' ; suitesparse='--backend=suitesparse' ; vanilla='--backend=suitesparse-vanilla'
+          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)
           echo $args
           coverage run -m pytest --randomly -v $args \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
@@ -188,23 +188,23 @@ jobs:
           G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
-          mapnumpy=' --mapnumpy' ; nomapnumpy=' --no-mapnumpy' ; suitesparse=' --backend=suitesparse' ; vanilla=' --backend=suitesparse-vanilla'
-          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
-                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
-                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
-                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
-                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)
+          mapnumpy='--mapnumpy' ; nomapnumpy='--no-mapnumpy' ; suitesparse='--backend=suitesparse' ; vanilla='--backend=suitesparse-vanilla'
+          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo " $mapnumpy"    ; elif [[ $windows ]] ; then echo " $nomapnumpy"  ; fi ; fi)$( \
+                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $nomapnumpy"  ; elif [[ $windows ]] ; then echo " $mapnumpy"    ; fi ; fi)$( \
+                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)$( \
+                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)$( \
+                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)
           echo $args
           coverage run -a -m pytest --randomly -v $args \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -10,96 +10,90 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ${{ matrix.cfg.os }}
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       fail-fast: false
+      # The build matrix is [os]x[slowtask] and then randomly chooses [pyver] and [sourcetype].
+      # This should ensure we'll have full code coverage (i.e., no chance of getting unlucky),
+      # since we need to run all slow tests on Windows and non-Windoes OSes.
+      # If important in the future, we can also randomize dependency versions.
       matrix:
-        cfg:
-          # Begin with fast, vanilla test
-          - { pyver: "3.10", os: "ubuntu-latest", testopts: "", sourcetype: "conda-forge" }
-          # Test ubuntu with conda-forge
-          - { pyver: "3.8", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.9", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.10", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          # Test macos with conda-forge
-          - { pyver: "3.8", os: "macos-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.9", os: "macos-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.10", os: "macos-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          # Test windows with conda-forge
-          - { pyver: "3.8", os: "windows-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.9", os: "windows-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          - { pyver: "3.10", os: "windows-latest", testopts: "--randomly", sourcetype: "conda-forge" }
-          # Test ubuntu with alternative methods to install dependencies
-          - { pyver: "3.10", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "wheel" }
-          - { pyver: "3.10", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "source" }
-          - { pyver: "3.10", os: "ubuntu-latest", testopts: "--randomly", sourcetype: "upstream" }
-          # Test misc
-          - { pyver: "3.8", os: "macos-latest", testopts: "--randomly", sourcetype: "upstream" }
-          - { pyver: "3.9", os: "windows-latest", testopts: "--randomly", sourcetype: "upstream" }
-
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        slowtask: ["pytest_normal", "pytest_bizarro", "pylint", "notebooks"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: RNG for Python version
+        uses: ddradar/choose-random-action@v2.0.2
+        id: pyver
+        with:
+          contents: |
+            "3.8"
+            "3.9"
+            "3.10"
+          weights: |
+            1
+            1
+            1
+      - name: RNG for source type of python-suitesparse-graphblas
+        uses: ddradar/choose-random-action@v2.0.2
+        id: sourcetype
+        with:
+          contents: |
+            conda-forge
+            wheel
+            source
+            upstream
+          weights: |
+            1
+            1
+            1
+            1
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
-          python-version: ${{ matrix.cfg.pyver }}
+          python-version: ${{ steps.pyver.outputs.selected }}
           channels: conda-forge,nodefaults
           channel-priority: strict
           activate-environment: graphblas
           auto-activate-base: false
-      # Randomly test one slow task per job (about 5% chance one group isn't run).
-      #
-      # TODO: have build matrix be [slowtask]x[os] and randomly choose [pyver] and [sourcetype].
-      # This should ensure we'll have full code coverage (i.e., no chance of getting unlucky).
-      # If important in the future, we could also randomize dependency versions.
-      - name: RNG for tests
-        uses: ddradar/choose-random-action@v2.0.2
-        id: slowtask
-        with:
-          contents: |
-            pytest_normal
-            pytest_bizarro
-            pylint
-            notebooks
-          weights: |
-            1
-            1
-            1
-            1
       - name: Update env
         run: |
+          # Install dependencies based on the needs of the job.
+          # Don't be overwhelmed! This may look scary at a glance, but each line makes sense.
+          # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
-            ${{ steps.slowtask.outputs.selected == 'pylint' && 'black pylint' || '' }} \
-            pandas numba scipy networkx cffi donfig pyyaml awkward
+            pandas numba scipy networkx cffi donfig pyyaml awkward \
+            ${{ matrix.slowtask == 'pylint' && 'black pylint' || '' }} \
+            ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
+            ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \
+            ${{ steps.sourcetype.outputs.selected != 'wheel' && '"graphblas>=7.4.0"' || '' }} \
+            ${{ steps.sourcetype.outputs.selected == 'conda-forge' && 'python-suitesparse-graphblas' || ''}} \
+            ${{ matrix.os != 'ubuntu-latest' && '"graphblas>=7.4.0"' || '' }} \
+            ${{ steps.sourcetype.outputs.selected == 'wheel' && matrix.os != 'ubuntu-latest' && 'python-suitesparse-graphblas' || '' }}
       - name: Build extension module
         run: |
-          if [[ ${{ matrix.cfg.sourcetype }} == "wheel" ]]; then
-              pip install suitesparse-graphblas
-          else
-              mamba install "graphblas>=7.4.0"
-          fi
-          if [[ ${{ matrix.cfg.sourcetype }} == "source" ]]; then
-              pip install --no-binary=all suitesparse-graphblas
-          elif [[ ${{ matrix.cfg.sourcetype }} == "upstream" ]]; then
-              mamba install cython
+          # We only have wheels for Linux right now
+          if [[ ${{ steps.sourcetype.outputs.selected }} == "wheel" && ${{ matrix.os }} == "ubuntu-latest" }} ]]; then
+              pip install --no-deps suitesparse-graphblas
+          elif [[ ${{ steps.sourcetype.outputs.selected }} == "source" ]]; then
+              pip install --no-deps --no-binary=all suitesparse-graphblas
+          elif [[ ${{ steps.sourcetype.outputs.selected }} == "upstream" ]]; then
               pip install --no-deps git+https://github.com/GraphBLAS/python-suitesparse-graphblas.git@main#egg=suitesparse-graphblas
-          elif [[ ${{ matrix.cfg.sourcetype }} == "conda-forge" ]]; then
-              mamba install python-suitesparse-graphblas
           fi
           pip install --no-deps -e .
       - name: Unit tests
         run: |
-          coverage run -m pytest ${{ matrix.cfg.testopts }} -v \
-            ${{ steps.slowtask.outputs.selected == 'pytest_normal' && '--runslow' || '' }}
+          coverage run -m pytest --randomly -v \
+            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
@@ -108,11 +102,11 @@ jobs:
             -e '/# pragma: is_grbscalar/! s/is_cscalar = False/is_cscalar = True/g' \
             -e '/# pragma: to_grb/ s/is_cscalar=True/is_cscalar=False/g' \
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
-          coverage run -a -m pytest ${{ matrix.cfg.testopts }} -v \
-            ${{ steps.slowtask.outputs.selected == 'pytest_bizarro' && '--runslow' || ''}}
+          coverage run -a -m pytest --randomly -v \
+            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || ''}}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
-        if: steps.slowtask.outputs.selected == 'pylint'
+        if: matrix.slowtask == 'pylint'
         run: |
           # Test (and cover) automatic initialization
           coverage run -a graphblas/tests/test_auto_init.py
@@ -128,19 +122,16 @@ jobs:
           coverage run -a script.py
           rm script.py
       - name: Auto-generated code check
-        if: steps.slowtask.outputs.selected == 'pylint'
+        if: matrix.slowtask == 'pylint'
         run: |
           # This step uses `black`
           coverage run -a -m graphblas.core.automethods
           coverage run -a -m graphblas.core.infixmethods
           git diff --exit-code
-      - name: Pylint (informational only; never fails)
-        if: steps.slowtask.outputs.selected == 'pylint'
-        run: pylint --exit-zero graphblas/
       - name: Coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.cfg.pyver}}/${{ matrix.cfg.testopts }}
+          COVERALLS_FLAG_NAME: ${{ matrix.os }}/${{ matrix.slowtask }}
           COVERALLS_PARALLEL: true
         run: |
           coverage xml
@@ -148,11 +139,12 @@ jobs:
           coveralls --service=github
       - name: codecov
         uses: codecov/codecov-action@v3
+      - name: Pylint (informational only; never fails)
+        if: matrix.slowtask == 'pylint'
+        run: pylint --exit-zero graphblas/
       - name: Notebooks Execution check
-        if: steps.slowtask.outputs.selected == 'notebooks'
-        run: |
-          mamba install matplotlib nbconvert jupyter 'ipython>=7'
-          jupyter nbconvert --to notebook --execute notebooks/*ipynb
+        if: matrix.slowtask == 'notebooks'
+        run: jupyter nbconvert --to notebook --execute notebooks/*ipynb
 
   finish:
     needs: build_and_test

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -59,8 +59,8 @@ jobs:
         id: spver
         with:
           contents: |
-            '=1.7.0'
-            '>1.7.0'
+            =1.7.0
+            >1.7.0
           weights: |
             1
             1
@@ -69,8 +69,8 @@ jobs:
         id: akver
         with:
           contents: |
-            '<2'
-            '>=2'
+            <2
+            >=2
           weights: |
             1
             1
@@ -92,8 +92,8 @@ jobs:
           # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
             pandas numba networkx cffi donfig pyyaml \
-            scipy${{ steps.spver.outputs.selected }} \
-            awkward${{ steps.akver.outputs.selected }} \
+            'scipy${{ steps.spver.outputs.selected }}' \
+            'awkward${{ steps.akver.outputs.selected }}' \
             ${{ matrix.slowtask == 'pylint' && 'black pylint' || '' }} \
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -155,7 +155,6 @@ jobs:
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
           suitesparse=--backend=suitesparse ; vanilla=--backend=suitesparse-vanilla
-          echo $A $B $C $D $E %F $G $H
           coverage run -m pytest --randomly -v \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }} \
             $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
@@ -177,12 +176,18 @@ jobs:
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
-          echo $A $B $C $D $E %F $G $H
           find graphblas -type f -name "*.py" -print0 | xargs -0 sed -i -s \
             -e '/# pragma: is_grbscalar/! s/is_cscalar=False/is_cscalar=True/g' \
             -e '/# pragma: is_grbscalar/! s/is_cscalar = False/is_cscalar = True/g' \
             -e '/# pragma: to_grb/ s/is_cscalar=True/is_cscalar=False/g' \
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
+          A=${{ needs.rngs.outputs.mapnumpy == 'A' || '' }} ; B=${{ needs.rngs.outputs.mapnumpy == 'B' || '' }}
+          C=${{ needs.rngs.outputs.mapnumpy == 'C' || '' }} ; D=${{ needs.rngs.outputs.mapnumpy == 'D' || '' }}
+          E=${{ needs.rngs.outputs.backend == 'E' || '' }} ; F=${{ needs.rngs.outputs.backend == 'F' || '' }}
+          G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
+          normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
+          ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
+          suitesparse=--backend=suitesparse ; vanilla=--backend=suitesparse-vanilla
           coverage run -a -m pytest --randomly -v \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }} \
             $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -27,6 +27,7 @@ jobs:
     #               +-----------------------+
     runs-on: ubuntu-latest
     outputs:
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
       rng: ${{ steps.random.outputs.selected }}
     steps:
       - name: RNG for mapnumpy
@@ -127,14 +128,24 @@ jobs:
           pip install --no-deps -e .
       - name: Unit tests
         run: |
+          echo ${{ needs.mapnumpy.outputs.rng }} ${{ matrix.slowtask }} ${{ matrix.os }}
+          echo ${{ needs.mapnumpy.outputs.rng == 'A' }}
+          echo ${{ needs.mapnumpy.outputs.rng == 'B' }}
+          echo ${{ needs.mapnumpy.outputs.rng == 'C' }}
+          echo ${{ needs.mapnumpy.outputs.rng == 'D' }}
+          echo ${{ matrix.slowtask == 'pytest_normal' }}
+          echo ${{ matrix.slowtask == 'pytest_bizarro' }}
+          echo ${{ matrix.os == 'ubuntu-latest' }}
+          echo ${{ matrix.os == 'windows-latest' }}
+          echo ${{ matrix.os == 'macos-latest' }}
           coverage run -m pytest --randomly -v \
             ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
@@ -147,12 +158,12 @@ jobs:
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
           coverage run -a -m pytest --randomly -v \
             ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Update env
         run: |
           # Install dependencies based on the needs of the job.
-          # Don't be overwhelmed! This may look scary at a glance, but each line makes sense.
+          # Don't panic! This may look scary at a glance, but each line makes sense.
           # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
             pandas numba scipy networkx cffi donfig pyyaml awkward \
@@ -229,7 +229,9 @@ jobs:
           coverage run -a script.py
           rm script.py
           # Tests whose coverage depend on order of tests :/
-          coverage run -a -m pytest -x -k test_binaryop_attributes_numpy --no-mapnumpy -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
+          # TODO: understand why these are order-dependent and try to fix
+          coverage run -a -m pytest -x --no-mapnumpy -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
+          # coverage run -a -m pytest -x --no-mapnumpy -k test_npmonoid graphblas/tests/test_numpyops.py --runslow
       - name: Auto-generated code check
         if: matrix.slowtask == 'pylint'
         run: |

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -154,25 +154,26 @@ jobs:
           G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
-          suitesparse=--backend=suitesparse ; vanilla=--backend=suitesparse-vanilla
-          coverage run -m pytest --randomly -v \
-            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }} \
-            $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi)
+          mapnumpy=' --mapnumpy' ; nomapnumpy=' --no-mapnumpy' ; suitesparse=' --backend=suitesparse' ; vanilla=' --backend=suitesparse-vanilla'
+          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)
+          echo $args
+          coverage run -m pytest --randomly -v $args \
+            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
@@ -187,25 +188,26 @@ jobs:
           G=${{ needs.rngs.outputs.backend == 'G' || '' }} ; H=${{ needs.rngs.outputs.backend == 'H' || '' }}
           normal=${{ matrix.slowtask == 'pytest_normal' || '' }} ; bizarro=${{ matrix.slowtask == 'pytest_bizarro' || '' }}
           ubuntu=${{ matrix.os == 'ubuntu-latest' || '' }} ; windows=${{ matrix.os == 'windows-latest' || '' }} ; macos=${{ matrix.os == 'macos-latest' || '' }}
-          suitesparse=--backend=suitesparse ; vanilla=--backend=suitesparse-vanilla
-          coverage run -a -m pytest --randomly -v \
-            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }} \
-            $(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo '--mapnumpy'    ; elif [[ $windows ]] ; then echo '--no-mapnumpy' ; fi ; fi) \
-            $(if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo '--no-mapnumpy' ; elif [[ $windows ]] ; then echo '--mapnumpy'    ; fi ; fi) \
-            $(if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi) \
-            $(if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse    ; elif [[ $windows ]] ; then echo $vanilla        ; fi ; fi) \
-            $(if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla        ; elif [[ $windows ]] ; then echo $suitesparse    ; fi ; fi)
+          mapnumpy=' --mapnumpy' ; nomapnumpy=' --no-mapnumpy' ; suitesparse=' --backend=suitesparse' ; vanilla=' --backend=suitesparse-vanilla'
+          args=$(if [[ $A && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $A && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $B && $normal  ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $B && $bizarro ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $C && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $C && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $D && $normal  ]] ; then if [[ $macos  ]] ; then echo $mapnumpy    ; elif [[ $windows ]] ; then echo $nomapnumpy  ; fi ; fi)$( \
+                 if [[ $D && $bizarro ]] ; then if [[ $macos  ]] ; then echo $nomapnumpy  ; elif [[ $windows ]] ; then echo $mapnumpy    ; fi ; fi)$( \
+                 if [[ $E && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $E && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $F && $normal  ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $F && $bizarro ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $G && $normal  ]] ; then if [[ $ubuntu ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $G && $bizarro ]] ; then if [[ $ubuntu ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)$( \
+                 if [[ $H && $normal  ]] ; then if [[ $macos  ]] ; then echo $suitesparse ; elif [[ $windows ]] ; then echo $vanilla     ; fi ; fi)$( \
+                 if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo $vanilla     ; elif [[ $windows ]] ; then echo $suitesparse ; fi ; fi)
+          echo $args
+          coverage run -a -m pytest --randomly -v $args \
+            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
         if: matrix.slowtask == 'pylint'

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -33,9 +33,9 @@ jobs:
         id: pyver
         with:
           contents: |
-            "3.8"
-            "3.9"
-            "3.10"
+            3.8
+            3.9
+            3.10
           weights: |
             1
             1

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -54,16 +54,6 @@ jobs:
             1
             1
             1
-      - name: RNG for SciPy version
-        uses: ddradar/choose-random-action@v2.0.2
-        id: spver
-        with:
-          contents: |
-            =1.7.0
-            >1.7.0
-          weights: |
-            1
-            1
       - name: RNG for Awkward version
         uses: ddradar/choose-random-action@v2.0.2
         id: akver
@@ -91,9 +81,8 @@ jobs:
           # Don't be overwhelmed! This may look scary at a glance, but each line makes sense.
           # Once we have wheels for all OSes, we can delete the last two lines.
           mamba install pytest coverage coveralls=3.3.1 pytest-randomly \
-            pandas numba networkx cffi donfig pyyaml \
-            'scipy${{ steps.spver.outputs.selected }}' \
-            'awkward${{ steps.akver.outputs.selected }}' \
+            pandas numba scipy networkx cffi donfig pyyaml \
+            "awkward${{ steps.akver.outputs.selected }}" \
             ${{ matrix.slowtask == 'pylint' && 'black pylint' || '' }} \
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build extension module
         run: |
           # We only have wheels for Linux right now
-          if [[ ${{ steps.sourcetype.outputs.selected }} == "wheel" && ${{ matrix.os }} == "ubuntu-latest" }} ]]; then
+          if [[ ${{ steps.sourcetype.outputs.selected }} == "wheel" && ${{ matrix.os }} == "ubuntu-latest" ]]; then
               pip install --no-deps suitesparse-graphblas
           elif [[ ${{ steps.sourcetype.outputs.selected }} == "source" ]]; then
               pip install --no-deps --no-binary=all suitesparse-graphblas

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -128,28 +128,29 @@ jobs:
           pip install --no-deps -e .
       - name: Unit tests
         run: |
-          echo ${{ needs.mapnumpy.outputs.rng }} ${{ matrix.slowtask }} ${{ matrix.os }}
-          echo ${{ needs.mapnumpy.outputs.rng == 'A' }}
-          echo ${{ needs.mapnumpy.outputs.rng == 'B' }}
-          echo ${{ needs.mapnumpy.outputs.rng == 'C' }}
-          echo ${{ needs.mapnumpy.outputs.rng == 'D' }}
-          echo ${{ matrix.slowtask == 'pytest_normal' }}
-          echo ${{ matrix.slowtask == 'pytest_bizarro' }}
-          echo ${{ matrix.os == 'ubuntu-latest' }}
-          echo ${{ matrix.os == 'windows-latest' }}
-          echo ${{ matrix.os == 'macos-latest' }}
           coverage run -m pytest --randomly -v \
             ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
+          is_A=${{ needs.mapnumpy.outputs.rng == 'A' }}
+          echo $is_A
+          echo ${{ $is_A && matrix.slowtask == 'pytest_normal' }}
           # Run tests again with Scalars being C scalars by default
           find graphblas -type f -name "*.py" -print0 | xargs -0 sed -i -s \
             -e '/# pragma: is_grbscalar/! s/is_cscalar=False/is_cscalar=True/g' \
@@ -158,13 +159,21 @@ jobs:
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
           coverage run -a -m pytest --randomly -v \
             ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
             ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -9,30 +9,36 @@ on:
       - main
 
 jobs:
-  mapnumpy:
+  rngs:
     # To achieve consistent coverage, we need a little bit of correlated collaboration.
     # Specifically, we need to make sure we run with and without `--mapnumpy` on slow tests.
-    # TODO: determine if we *also* need to run both backends on slow tests.
+    # We also use correlated RNG to run both backends on slow tests.
+    #
+    # {A,B,C,D},yes = --mapnumpy
+    # {A,B,C,D},no = --no-mapnumpy
+    # {D,E,F,G},yes = --backend=suitesparse
+    # {D,E,F,G},no = --backend=suitesparse-vanilla
     #
     #                   linux   windows osx
     #               +-----------------------+
-    #   A   normal  |   yes     no          |
-    #   A   bizarro |   no      yes         |
-    #   B   normal  |           no      yes |
-    #   B   bizarro |           yes     no  |
-    #   C   normal  |   no      yes         |
-    #   C   bizarro |   yes     no          |
-    #   D   normal  |           yes     no  |
-    #   D   bizarro |           no      yes |
+    # A  E  normal  |   yes     no          |
+    # A  E  bizarro |   no      yes         |
+    # B  F  normal  |           no      yes |
+    # B  F  bizarro |           yes     no  |
+    # C  G  normal  |   no      yes         |
+    # C  G  bizarro |   yes     no          |
+    # D  H  normal  |           yes     no  |
+    # D  H  bizarro |           no      yes |
     #               +-----------------------+
     runs-on: ubuntu-latest
     outputs:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs
-      rng: ${{ steps.random.outputs.selected }}
+      mapnumpy: ${{ steps.mapnumpy.outputs.selected }}
+      backend: ${{ steps.backend.outputs.selected }}
     steps:
       - name: RNG for mapnumpy
         uses: ddradar/choose-random-action@v2.0.2
-        id: random
+        id: mapnumpy
         with:
           contents: |
             A
@@ -44,8 +50,22 @@ jobs:
             1
             1
             1
+      - name: RNG for backend
+        uses: ddradar/choose-random-action@v2.0.2
+        id: backend
+        with:
+          contents: |
+            E
+            F
+            G
+            H
+          weights: |
+            1
+            1
+            1
+            1
   build_and_test:
-    needs: mapnumpy
+    needs: rngs
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -129,27 +149,41 @@ jobs:
       - name: Unit tests
         run: |
           coverage run -m pytest --randomly -v \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
             ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
-          is_A=${{ needs.mapnumpy.outputs.rng == 'A' }}
-          echo $is_A
           # Run tests again with Scalars being C scalars by default
           find graphblas -type f -name "*.py" -print0 | xargs -0 sed -i -s \
             -e '/# pragma: is_grbscalar/! s/is_cscalar=False/is_cscalar=True/g' \
@@ -157,22 +191,38 @@ jobs:
             -e '/# pragma: to_grb/ s/is_cscalar=True/is_cscalar=False/g' \
             -e '/# pragma: to_grb/ s/is_cscalar = True/is_cscalar = False/g'
           coverage run -a -m pytest --randomly -v \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
-            ${{ needs.mapnumpy.outputs.rng == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'A' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'B' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'C' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--no-mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.mapnumpy == 'D' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--mapnumpy' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'E' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'F' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'ubuntu-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'G' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'macos-latest' && '--backend=suitesparse' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_normal' && matrix.os == 'windows-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'macos-latest' && '--backend=suitesparse-vanilla' || '' }} \
+            ${{ needs.rngs.outputs.backend == 'H' && matrix.slowtask == 'pytest_bizarro' && matrix.os == 'windows-latest' && '--backend=suitesparse' || '' }} \
             ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         additional_dependencies: [tomli]
         files: ^(graphblas|docs)/
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.212
+    rev: v0.0.213
     hooks:
       - id: ruff
         args: [--force-exclude]

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--nonblocking",
         "--no-blocking",
+        "--noblocking",
         "--non-blocking",
         dest="blocking",
         action="store_false",
@@ -30,5 +31,12 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--mapnumpy", action="store_true", default=None, help="map numpy ops to GraphBLAS ops"
+    )
+    parser.addoption(
+        "--nomapnumpy",
+        "--no-mapnumpy",
+        dest="mapnumpy",
+        action="store_false",
+        help="don't map numpy ops to GraphBLAS ops",
     )
     parser.addoption("--randomly", action="store_true", help="run random test config")

--- a/graphblas/core/operator.py
+++ b/graphblas/core/operator.py
@@ -462,7 +462,6 @@ class TypedUserBinaryOp(TypedOpBase):
         if self._monoid is None:
             monoid = self.parent.monoid
             if monoid is not None and self.type in monoid:
-                1 / 0  # XXX: how is this covered?!
                 self._monoid = monoid[self.type]
         return self._monoid
 

--- a/graphblas/core/operator.py
+++ b/graphblas/core/operator.py
@@ -462,6 +462,7 @@ class TypedUserBinaryOp(TypedOpBase):
         if self._monoid is None:
             monoid = self.parent.monoid
             if monoid is not None and self.type in monoid:
+                1 / 0  # XXX: how is this covered?!
                 self._monoid = monoid[self.type]
         return self._monoid
 

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_configure(config):
     if backend is None:
         if randomly:
             backend = "suitesparse" if np.random.rand() < 0.5 else "suitesparse-vanilla"
-        else:  # pragma: no cover
+        else:
             backend = "suitesparse"
     blocking = config.getoption("--blocking", True)
     if blocking is None:  # pragma: no branch
@@ -30,8 +30,8 @@ def pytest_configure(config):
         mapnumpy = np.random.rand() < 0.5 if randomly else False
     runslow = config.getoption("--runslow", False)
     if runslow is None:
-        runslow = np.random.rand() < 0.25 if randomly else False
-        # runslow = False  # XXX TODO
+        # Add a small amount of randomization to be safer
+        runslow = np.random.rand() < 0.05 if randomly else False
     config.runslow = runslow
 
     gb.config.set(autocompute=False, mapnumpy=mapnumpy)

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -14,7 +14,7 @@ orig_semirings = set()
 def pytest_configure(config):
     randomly = config.getoption("--randomly", False)
     backend = config.getoption("--backend", None)
-    if backend is None:  # pragma: no branch
+    if backend is None:
         if randomly:
             backend = "suitesparse" if np.random.rand() < 0.5 else "suitesparse-vanilla"
         else:  # pragma: no cover
@@ -26,11 +26,12 @@ def pytest_configure(config):
     if record is None:  # pragma: no branch
         record = np.random.rand() < 0.5 if randomly else False
     mapnumpy = config.getoption("--mapnumpy", False)
-    if mapnumpy is None:  # pragma: no branch
+    if mapnumpy is None:
         mapnumpy = np.random.rand() < 0.5 if randomly else False
     runslow = config.getoption("--runslow", False)
-    if runslow is None:  # pragma: no branch
-        runslow = np.random.rand() < 0.25 if randomly else False
+    if runslow is None:
+        # runslow = np.random.rand() < 0.25 if randomly else False
+        runslow = False
     config.runslow = runslow
 
     gb.config.set(autocompute=False, mapnumpy=mapnumpy)

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -30,8 +30,8 @@ def pytest_configure(config):
         mapnumpy = np.random.rand() < 0.5 if randomly else False
     runslow = config.getoption("--runslow", False)
     if runslow is None:
-        # runslow = np.random.rand() < 0.25 if randomly else False
-        runslow = False
+        runslow = np.random.rand() < 0.25 if randomly else False
+        # runslow = False  # XXX TODO
     config.runslow = runslow
 
     gb.config.set(autocompute=False, mapnumpy=mapnumpy)

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -17,7 +17,7 @@ def pytest_configure(config):
     if backend is None:  # pragma: no branch
         if randomly:
             backend = "suitesparse" if np.random.rand() < 0.5 else "suitesparse-vanilla"
-        else:
+        else:  # pragma: no cover
             backend = "suitesparse"
     blocking = config.getoption("--blocking", True)
     if blocking is None:  # pragma: no branch

--- a/graphblas/tests/test_numpyops.py
+++ b/graphblas/tests/test_numpyops.py
@@ -228,7 +228,7 @@ def test_npmonoid():
             assert len(op.types) > 0, op.name
             if gb_left.dtype not in op.types or binary_name in blocklist.get(
                 gb_left.dtype.name, ()
-            ):
+            ):  # pragma: no cover (flaky)
                 continue
             with np.errstate(divide="ignore", over="ignore", under="ignore", invalid="ignore"):
                 gb_result = gb_left.ewise_mult(gb_right, op).new()

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -717,17 +717,20 @@ def test_op_namespace():
     assert selectnames - opnames == selectnames, selectnames - opnames
 
 
+def test_binaryop_attributes_numpy():
+    # Some coverage from this test depends on order of tests
+    assert binary.numpy.add[int].monoid is monoid.numpy.add[int]
+    assert binary.numpy.subtract[int].monoid is None
+    assert binary.numpy.add.monoid is monoid.numpy.add
+    assert binary.numpy.subtract.monoid is None
+
+
 @pytest.mark.slow
 def test_binaryop_attributes():
     assert binary.plus[int].monoid is monoid.plus[int]
     assert binary.minus[int].monoid is None
     assert binary.plus.monoid is monoid.plus
     assert binary.minus.monoid is None
-
-    assert binary.numpy.add[int].monoid is monoid.numpy.add[int]
-    assert binary.numpy.subtract[int].monoid is None
-    assert binary.numpy.add.monoid is monoid.numpy.add
-    assert binary.numpy.subtract.monoid is None
 
     def plus(x, y):
         return x + y  # pragma: no cover (numba)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ select = [
 ignore = [
     "D203",  # 1 blank line required before class docstring (Note: conflicts with D211, which is preferred)
     "SIM105",  # Use contextlib.suppress(...) instead of try-except-pass (Note: try-except-pass is much faster)
+    "SIM108",  # Use ternary operator ... instead of if-else-block (Note: if-else better for coverage and sometimes clearer)
 ]
 [tool.ruff.per-file-ignores]
 "graphblas/core/operator.py" = ["S102"]


### PR DESCRIPTION
Randomize Python version and from where to install `python-suitesparse-graphblas`.

The full matrix is over what is more important: that all tests (slow tests, notebooks, etc.) are run on all OSes. This should ensure that our code coverage doesn't fluctuate based on random chance (as it currently does), which will help us achieve and _enforce_ 100% code coverage (#355).

We actually don't have a strong dependence on Python version and the source of `python-suitesparse-graphblas`, so it makes more sense to randomize on those. We still want to test them though, so randomizing makes the most sense imho.

I consolidated the logic of what is installed by conda (_ahem_, mamba). This simplifies the CI config overall, but it makes for a pretty large `mamba install` statement (which we'll be able to simplify once we have wheels for Windows and OS X).

This drops us down to 12 CI jobs in the main scripts (from 15 jobs) :tada: . It would be easy to up it back to 15 if desired. Another benefit of this form is that we can add additional Python versions (such as Python 3.11, PyPy, etc.) without increasing the number of CI jobs.