### PR TITLE
Try switching back to conda (from mamba)

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -125,9 +125,7 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
+          auto-update-conda: true
           python-version: ${{ steps.pyver.outputs.selected }}
           channels: conda-forge,nodefaults
           channel-priority: strict
@@ -178,7 +176,7 @@ jobs:
           echo "versions: np${npver} sp${spver} pd${pdver} ak${akver} nx${nxver} numba${numbaver} yaml${yamlver}"
 
           # Once we have wheels for all OSes, we can delete the last two lines.
-          mamba install pytest coverage coveralls=3.3.1 pytest-randomly cffi donfig pyyaml${yamlver} \
+          conda install pytest coverage coveralls=3.3.1 pytest-randomly cffi donfig pyyaml${yamlver} \
             pandas${pdver} scipy${spver} numpy${npver} awkward${akver} networkx${nxver} numba${numbaver} \
             ${{ matrix.slowtask == 'pytest_bizarro' && 'black' || '' }} \
             ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7"' || '' }} \

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,11 @@ sphinx:
 
 # Try to make build faster with mamba. See:
 # https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba
-# build:
-#   os: "ubuntu-20.04"
-#   tools:
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "miniconda3-4.7"
 #     python: "mambaforge-4.10"
 
 conda:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,10 +8,10 @@ sphinx:
 
 # Try to make build faster with mamba. See:
 # https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba
-build:
-  os: "ubuntu-20.04"
-  tools:
-    python: "mambaforge-4.10"
+# build:
+#   os: "ubuntu-20.04"
+#   tools:
+#     python: "mambaforge-4.10"
 
 conda:
   environment: docs/env.yml


### PR DESCRIPTION
`conda` has gotten faster (such as parallel downloads) and it's probably what most of our users use, so let's try switching back to `conda` from `mamba`.

We first switched to `mamba` in #329 and #338.

We have occasionally encountered timeout errors when using `mamba`, and the warnings on CI are pretty annoying.