### PR TITLE
Require setuptools>=64 for build backend

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check with twine
         run: python -m twine check --strict dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools >=61",
+    "setuptools >=64",
     "setuptools-git-versioning",
 ]
 


### PR DESCRIPTION
This is to support editable installs with the new way of doing things:
https://setuptools.pypa.io/en/latest/history.html#v64-0-0