### PR TITLE
Add `op.is_idempotent` property to Monoids that means `op(x, x) == x`

### DIFF
--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -297,6 +297,8 @@ def test_monoid_parameterized():
     assert bin_op.monoid is monoid
     assert bin_op(1).monoid is monoid(1)
     assert monoid(2) is bin_op(2).monoid
+    assert not monoid.is_idempotent
+    assert not monoid(1).is_idempotent
     # However, this still fails.
     # For this to work, we would need `bin_op1` to know it was created from a
     # ParameterizedBinaryOp. It would then need to check to see if the parameterized
@@ -353,9 +355,12 @@ def test_monoid_parameterized():
         raise ValueError("hahaha!")
 
     assert bin_op.monoid is None
-    monoid = Monoid.register_anonymous(bin_op, bad_identity, name="broken_monoid")
+    monoid = Monoid.register_anonymous(
+        bin_op, bad_identity, is_idempotent=True, name="broken_monoid"
+    )
     assert bin_op.monoid is monoid
     assert bin_op(1).monoid is None
+    assert monoid.is_idempotent
 
 
 @pytest.mark.slow
@@ -1327,3 +1332,16 @@ def test_deprecated():
         gb.op.secondj
     with pytest.warns(DeprecationWarning, match="please use"):
         gb.agg.argmin
+
+
+def test_is_idempotent():
+    assert monoid.min.is_idempotent
+    assert monoid.max[int].is_idempotent
+    assert monoid.lor.is_idempotent
+    assert monoid.band.is_idempotent
+    assert monoid.numpy.gcd.is_idempotent
+    assert not monoid.plus.is_idempotent
+    assert not monoid.times[float].is_idempotent
+    assert not monoid.numpy.equal.is_idempotent
+    with pytest.raises(AttributeError):
+        binary.min.is_idempotent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,10 @@ filterwarnings = [
     # and: https://docs.pytest.org/en/7.2.x/how-to/capture-warnings.html#controlling-warnings
     "error",
     "ignore:`np.bool` is a deprecated alias:DeprecationWarning:sparse._umath",  # sparse <0.13
+    # setuptools v67.3.0 deprecated `pkg_resources.declare_namespace` on 13 Feb 2023. See:
+    # https://setuptools.pypa.io/en/latest/history.html#v67-3-0
+    # TODO: check if this is still necessary in 2025
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:pkg_resources",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ ignore = [
     # Intentionally ignored
     "COM812",  # Trailing comma missing
     "D203",  # 1 blank line required before class docstring (Note: conflicts with D211, which is preferred)
+    "D400",  # First line should end with a period (Note: prefer D415, which also allows "?" and "!")
     "PLR0911",  # Too many return statements
     "PLR0912",  # Too many branches
     "PLR0913",  # Too many arguments to function call


### PR DESCRIPTION
Closes #387 

I'm going to want to use this property in `graphblas-algorithms`.