### PR TITLE
Deprecated `unary.position` points to `indexunary.rowindex`

### DIFF
--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -1317,7 +1317,7 @@ def test_op_ss():
 def test_deprecated():
     with pytest.warns(DeprecationWarning, match="please use"):
         gb.unary.erf
-    with pytest.warns(DeprecationWarning, match="please use"):
+    with pytest.warns(DeprecationWarning, match="please use `gb.indexunary.rowindex`"):
         gb.unary.positioni
     with pytest.warns(DeprecationWarning, match="please use"):
         gb.binary.firsti

--- a/graphblas/unary/__init__.py
+++ b/graphblas/unary/__init__.py
@@ -12,8 +12,11 @@ def __getattr__(key):
     if key in _deprecated:
         import warnings
 
+        alt = {"positioni": "indexunary.rowindex", "positionj": "indexunary.colindex"}.get(key, "")
+        if alt:
+            alt = f"`gb.{alt}` or "
         warnings.warn(
-            f"`gb.unary.{key}` is deprecated; please use `gb.unary.ss.{key}` instead. "
+            f"`gb.unary.{key}` is deprecated; please use {alt}`gb.unary.ss.{key}` instead. "
             f"`{key}` is specific to SuiteSparse:GraphBLAS. "
             f"`gb.unary.{key}` will be removed in version 2023.9.0 or later.",
             DeprecationWarning,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,10 @@ filterwarnings = [
     # and: https://docs.pytest.org/en/7.2.x/how-to/capture-warnings.html#controlling-warnings
     "error",
     "ignore:`np.bool` is a deprecated alias:DeprecationWarning:sparse._umath",  # sparse <0.13
+    # setuptools v67.3.0 deprecated `pkg_resources.declare_namespace` on 13 Feb 2023. See:
+    # https://setuptools.pypa.io/en/latest/history.html#v67-3-0
+    # TODO: check if this is still necessary in 2025
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:pkg_resources",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Closes #383 