### PR TITLE
Fix path to logo in docs (include `_static` in path)

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -6,6 +6,7 @@
 }
 
 .intro-card {
+    background-color: var(--pst-color-background);
     margin-bottom: 30px;
 }
 
@@ -49,6 +50,29 @@
 
 p.rubric {
     border-bottom: none;
+}
+
+button.navbar-btn.rounded-circle {
+    padding: 0.25rem;
+}
+
+button.navbar-btn.search-button {
+    color: var(--pst-color-text-muted);
+    padding: 0;
+}
+
+button.navbar-btn:hover
+{
+    color: var(--pst-color-primary);
+}
+
+button.theme-switch-button {
+    font-size: calc(var(--pst-font-size-icon) - .1rem);
+    border: none;
+}
+
+button span.theme-switch:hover {
+    color: var(--pst-color-primary);
 }
 
 /* Styling for Jupyter Notebook ReST Exports */

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ html_theme_options = {
     },
     "github_url": "https://github.com/python-graphblas/python-graphblas",
 }
+html_show_sourcelink = False
 
 autodoc_member_order = "groupwise"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,8 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_theme_options = {
     "logo": {
-        "image_light": "img/logo-name-light.svg",
-        "image_dark": "img/logo-name-dark.svg",
+        "image_light": "_static/img/logo-name-light.svg",
+        "image_dark": "_static/img/logo-name-dark.svg",
     },
     "github_url": "https://github.com/python-graphblas/python-graphblas",
 }

--- a/docs/env.yml
+++ b/docs/env.yml
@@ -19,5 +19,5 @@ dependencies:
     - commonmark  # For RTD
     - nbsphinx
     - numpydoc
-    - pydata-sphinx-theme
-    - sphinx-panels
+    - pydata-sphinx-theme=0.13.1
+    - sphinx-panels=0.6.0


### PR DESCRIPTION
Our logo just disappeared in the docs. Adding `_static/` to the path seems to fix it. Is `html_static_path` supposed to do this for us?

Reported here: https://github.com/python-graphblas/python-graphblas/issues/396#issuecomment-1458955342

Maybe we should pin to a specific version of `pydata-sphinx-theme`.