### PR TITLE
Fix infix expression `_value` and `_expr` usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.1
+    rev: v0.12.2
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
@@ -47,7 +47,7 @@ repos:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.257
+    rev: v0.0.259
     hooks:
       - id: ruff
         args: [--fix-only]
@@ -75,7 +75,7 @@ repos:
         additional_dependencies: [tomli]
         files: ^(graphblas|docs)/
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.257
+    rev: v0.0.259
     hooks:
       - id: ruff
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/environment.yml
+++ b/environment.yml
@@ -99,6 +99,7 @@ dependencies:
     # - snakeviz
     # - sphinx-lint
     # - sympy
+    # - tuna
     # - twine
     # - vim
     # - yesqa

--- a/graphblas/core/formatting.py
+++ b/graphblas/core/formatting.py
@@ -1,3 +1,4 @@
+# This file imports pandas, so it should only be imported when formatting
 import numpy as np
 
 from .. import backend, config, monoid, unary

--- a/graphblas/core/infix.py
+++ b/graphblas/core/infix.py
@@ -16,11 +16,11 @@ InfixExprBase._expect_type = _expect_type
 
 
 def _ewise_add_to_expr(self):
-    if self._value is not None:
-        return self._value
+    if self._expr is not None:
+        return self._expr
     if self.left.dtype == BOOL and self.right.dtype == BOOL:
-        self._value = self.left.ewise_add(self.right, lor)
-        return self._value
+        self._expr = self.left.ewise_add(self.right, lor)
+        return self._expr
     raise TypeError(
         "Bad dtypes for `x | y`!  Automatic computation of `x | y` infix expressions is only valid "
         f"for BOOL dtypes.  The argument dtypes are {self.left.dtype} and {self.right.dtype}.\n\n"
@@ -30,11 +30,11 @@ def _ewise_add_to_expr(self):
 
 
 def _ewise_mult_to_expr(self):
-    if self._value is not None:
-        return self._value
+    if self._expr is not None:
+        return self._expr
     if self.left.dtype == BOOL and self.right.dtype == BOOL:
-        self._value = self.left.ewise_mult(self.right, land)
-        return self._value
+        self._expr = self.left.ewise_mult(self.right, land)
+        return self._expr
     raise TypeError(
         "Bad dtypes for `x & y`!  Automatic computation of `x & y` infix expressions is only valid "
         f"for BOOL dtypes.  The argument dtypes are {self.left.dtype} and {self.right.dtype}.\n\n"

--- a/graphblas/core/recorder.py
+++ b/graphblas/core/recorder.py
@@ -3,7 +3,6 @@ import collections
 from ..dtypes import DataType
 from . import base, lib
 from .base import _recorder
-from .formatting import CSS_STYLE
 from .mask import Mask
 from .matrix import TransposedMatrix
 from .operator import TypedOpBase
@@ -103,6 +102,8 @@ class Recorder:
         return self._token is not None and _recorder.get(base._prev_recorder) is self
 
     def _repr_base_(self):
+        from .formatting import CSS_STYLE
+
         status = (
             '<div style="'
             "height: 12px; "

--- a/graphblas/tests/test_infix.py
+++ b/graphblas/tests/test_infix.py
@@ -342,3 +342,21 @@ def test_inplace_infix(s1, v1, v2, A1, A2):
         expr @= A
     with pytest.raises(TypeError, match="not supported"):
         s1 @= v1
+
+
+@autocompute
+def test_infix_expr_value_types():
+    """Test bug where `infix_expr._value` was used as MatrixExpression or Matrix"""
+    from graphblas.core.matrix import MatrixExpression
+
+    A = Matrix(int, 3, 3)
+    A << 1
+    expr = A @ A.T
+    assert expr._expr is None
+    assert expr._value is None
+    assert type(expr._get_value()) is Matrix
+    assert type(expr._expr) is MatrixExpression
+    assert type(expr.new()) is Matrix
+    assert expr._expr is not None
+    assert expr._value is None
+    assert type(expr.new()) is Matrix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,7 +318,8 @@ ignore = [
 "graphblas/core/ss/matrix.py" = ["NPY002"]  # numba doesn't support rng generator yet
 "graphblas/core/ss/vector.py" = ["NPY002"]  # numba doesn't support rng generator yet
 "graphblas/ss/_core.py" = ["N999"]  # We want _core.py to be underscopre
-"graphblas/tests/*py" = ["S101", "T201", "D103", "D100", "SIM300"]  # Allow assert, print, no docstring, and yoda
+# Allow assert, pickle, RNG, print, no docstring, and yoda in tests
+"graphblas/tests/*py" = ["S101", "S301", "S311", "T201", "D103", "D100", "SIM300"]
 "graphblas/tests/test_formatting.py" = ["E501"]  # Allow long lines
 "graphblas/**/__init__.py" = ["F401"]  # Allow unused imports (w/o defining `__all__`)
 "scripts/*.py" = ["INP001"]  # Not a package


### PR DESCRIPTION
Previously, `infixexpr._value` was sometimes `MatrixExpression` and sometimes `Matrix`. Scary!

Fixes #416.