### PR TITLE
Improve import times

### DIFF
--- a/graphblas/core/operator.py
+++ b/graphblas/core/operator.py
@@ -2741,19 +2741,6 @@ class Monoid(OpBase):
         # Builtin monoids that are idempotent; i.e., `op(x, x) == x` for any x
         for name in ["any", "band", "bor", "land", "lor", "max", "min"]:
             getattr(monoid, name)._is_idempotent = True
-        for name in [
-            "bitwise_and",
-            "bitwise_or",
-            "fmax",
-            "fmin",
-            "gcd",
-            "logical_and",
-            "logical_or",
-            "maximum",
-            "minimum",
-        ]:
-            getattr(monoid.numpy, name)._is_idempotent = True
-
         # Allow some functions to work on UDTs
         any_ = monoid.any
         any_._identity = 0

--- a/graphblas/monoid/numpy.py
+++ b/graphblas/monoid/numpy.py
@@ -140,6 +140,19 @@ _numpy_to_graphblas = {
 # _graphblas_to_numpy = {val: key for key, val in _numpy_to_graphblas.items()}  # Soon...
 # Not included: maximum, minimum, gcd, hypot, logaddexp, logaddexp2
 
+# True if ``monoid(x, x) == x`` for any x.
+_idempotent = {
+    "bitwise_and",
+    "bitwise_or",
+    "fmax",
+    "fmin",
+    "gcd",
+    "logical_and",
+    "logical_or",
+    "maximum",
+    "minimum",
+}
+
 
 def __dir__():
     return globals().keys() | _delayed.keys() | _monoid_identities.keys()
@@ -163,5 +176,7 @@ def __getattr__(name):
         from ..core import operator
 
         func = getattr(_binary.numpy, name)
-        operator.Monoid.register_new(f"numpy.{name}", func, _monoid_identities[name])
+        operator.Monoid.register_new(
+            f"numpy.{name}", func, _monoid_identities[name], is_idempotent=name in _idempotent
+        )
     return globals()[name]


### PR DESCRIPTION
Import times regressed in #388. This PR fixes it.

A nice way to visualize import times is with https://github.com/nschloe/tuna

Now, as before, import times are dominated by numba and numpy.

I looked at timing for "Test Imports" Github Actions to identify what caused the regression:
https://github.com/python-graphblas/python-graphblas/actions/workflows/imports.yml