### PR TITLE
Add logo and images to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,11 @@
 # To run: `pre-commit run --all-files`
 # To update: `pre-commit autoupdate`
 #  - &flake8_dependencies below needs updated manually
+ci:
+    # See: https://pre-commit.ci/#configuration
+    autofix_prs: false
+    autoupdate_schedule: monthly
+    skip: [pylint, no-commit-to-branch]
 fail_fast: true
 default_language_version:
     python: python3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,12 @@
 recursive-include graphblas *.py
+prune docs
+prune scripts
 include setup.py
 include README.md
 include LICENSE
 include MANIFEST.in
 include graphblas/graphblas.yaml
 include graphblas/tests/pickle*.pkl
+include docs/_static/img/logo-name-medium.svg
+include docs/_static/img/draw-example.png
+include docs/_static/img/repr-matrix.png

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/python-graphblas.svg)](https://anaconda.org/conda-forge/python-graphblas)
 [![pypi](https://img.shields.io/pypi/v/python-graphblas.svg)](https://pypi.python.org/pypi/python-graphblas/)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/python-graphblas)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/python-graphblas)](https://pypi.python.org/pypi/python-graphblas/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/python-graphblas/python-graphblas/blob/main/LICENSE)
 <br>
 [![Tests](https://github.com/python-graphblas/python-graphblas/workflows/Tests/badge.svg?branch=main)](https://github.com/python-graphblas/python-graphblas/actions)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-# Python-graphblas
+![Python-graphblas](docs/_static/img/logo-name-medium.svg)
 
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/python-graphblas.svg)](https://anaconda.org/conda-forge/python-graphblas)
 [![pypi](https://img.shields.io/pypi/v/python-graphblas.svg)](https://pypi.python.org/pypi/python-graphblas/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/python-graphblas)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/python-graphblas/python-graphblas/blob/main/LICENSE)
+<br>
 [![Tests](https://github.com/python-graphblas/python-graphblas/workflows/Tests/badge.svg?branch=main)](https://github.com/python-graphblas/python-graphblas/actions)
 [![Docs](https://readthedocs.org/projects/python-graphblas/badge/?version=latest)](https://python-graphblas.readthedocs.io/en/latest/)
 [![Coverage](https://coveralls.io/repos/python-graphblas/python-graphblas/badge.svg?branch=main)](https://coveralls.io/r/python-graphblas/python-graphblas)
+<br>
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7328791.svg)](https://doi.org/10.5281/zenodo.7328791)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/python-graphblas/python-graphblas/HEAD?filepath=notebooks%2FIntro%20to%20GraphBLAS%20%2B%20SSSP%20example.ipynb)
 [![Discord](https://img.shields.io/badge/Chat-Discord-blue)](https://discord.com/invite/vur45CbwMz)
 
 Python library for GraphBLAS: high-performance sparse linear algebra for scalable graph analytics.
+For algorithms, see
+[`graphblas-algorithms`](https://github.com/python-graphblas/graphblas-algorithms).
 
 - **Documentation:** [https://python-graphblas.readthedocs.io/](https://python-graphblas.readthedocs.io/)
   - **GraphBLAS C API:** [https://graphblas.org/docs/GraphBLAS_API_C_v2.0.0.pdf](https://graphblas.org/docs/GraphBLAS_API_C_v2.0.0.pdf)
@@ -21,6 +25,11 @@ Python library for GraphBLAS: high-performance sparse linear algebra for scalabl
 - **Github discussions:** [https://github.com/python-graphblas/python-graphblas/discussions](https://github.com/python-graphblas/python-graphblas/discussions)
 - **Weekly community call:** [https://github.com/python-graphblas/python-graphblas/issues/247](https://github.com/python-graphblas/python-graphblas/issues/247)
 - **Chat via Discord:** [https://discord.com/invite/vur45CbwMz](https://discord.com/invite/vur45CbwMz) in the [#graphblas channel](https://discord.com/channels/786703927705862175/1024732940233605190)
+
+<p float="left">
+  <img src="docs/_static/img/draw-example.png" width="231" align="top" alt="Directed graph", title="Directed graph"/>
+  <img src="docs/_static/img/repr-matrix.png" width="231" align="top" alt="Adjacency matrix" title="Adjacency matrix"/>
+</p>
 
 ## Install
 Install the latest version of Python-graphblas via conda:
@@ -39,7 +48,7 @@ The following are not required by python-graphblas, but may be needed for certai
 
 - `pandas` – required for nicer `__repr__`;
 - `matplotlib` – required for basic plotting of graphs;
-- `scipy` – used in io module to read/write `scipy.sparse` format;
+- `scipy` – used in `io` module to read/write `scipy.sparse` format;
 - `networkx` – used in `io` module to interface with `networkx` graphs;
 - `fast-matrix-market` - for faster read/write of Matrix Market files with `gb.io.mmread` and `gb.io.mmwrite`.
 

--- a/docs/_static/img/logo-name-medium.svg
+++ b/docs/_static/img/logo-name-medium.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="318.67502"
+   height="89.827674"
+   viewBox="0 0 41.983479 11.88345"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs130" />
+  <g
+     id="g715"
+     style="fill:#ff0000"
+     transform="translate(-9.9602331,-10.294627)" />
+  <text
+     xml:space="preserve"
+     transform="matrix(0.14905063,0,0,0.14905063,-0.46026941,9.6383744)"
+     id="text1199"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:64px;font-family:'Euphemia UCAS';-inkscape-font-specification:'Euphemia UCAS';white-space:pre;shape-inside:url(#rect1201);display:inline;fill:#818081;stroke:#818081"><tspan
+       x="0"
+       y="0"
+       id="tspan3605">graphblas</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.21364px;font-family:'Euphemia UCAS';-inkscape-font-specification:'Euphemia UCAS';fill:#818081;stroke:#818081;stroke-width:0.175568"
+     x="1.8869469"
+     y="3.3232677"
+     id="text1225"
+     transform="scale(1.1306953,0.88441157)"><tspan
+       id="tspan1223"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.21364px;font-family:'Euphemia UCAS';-inkscape-font-specification:'Euphemia UCAS';stroke-width:0.175568"
+       x="1.8869469"
+       y="3.3232677">python-</tspan></text>
+</svg>


### PR DESCRIPTION
Small changes to try to make the README more attractive.

I made a new version of the "python-graphblas" logo that is twice as large and hopefully looks okay in both dark and light mode.

I added images of a graph and the corresponding adjacency matrix as shown by our notebook repr.

I added these images to MANIFEST so they will show on PyPI.

I link to `graphblas-algorithms`.

I broke the badges up into three lines.

And, finally, I'm playing around with https://pre-commit.ci which may be able to replace our lint CI action.