### PR TITLE
Allow `__index__` only for integral dtypes on Scalars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 ci:
   # See: https://pre-commit.ci/#configuration
   autofix_prs: false
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
   skip: [pylint, no-commit-to-branch]
@@ -51,7 +51,7 @@ repos:
       - id: isort
   # Let's keep `pyupgrade` even though `ruff --fix` probably does most of it
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.9.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -61,12 +61,12 @@ repos:
       - id: auto-walrus
         args: [--line-length, "100"]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
       - id: black-jupyter
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.277
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.278
     hooks:
       - id: ruff
         args: [--fix-only, --show-fixes]
@@ -93,8 +93,8 @@ repos:
         types_or: [python, rst, markdown]
         additional_dependencies: [tomli]
         files: ^(graphblas|docs)/
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.277
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.278
     hooks:
       - id: ruff
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/graphblas/core/scalar.py
+++ b/graphblas/core/scalar.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 
 from .. import backend, binary, config, monoid
-from ..dtypes import _INDEX, FP64, lookup_dtype, unify
+from ..dtypes import _INDEX, FP64, _index_dtypes, lookup_dtype, unify
 from ..exceptions import EmptyObject, check_status
 from . import _has_numba, _supports_udfs, automethods, ffi, lib, utils
 from .base import BaseExpression, BaseType, call
@@ -158,7 +158,11 @@ class Scalar(BaseType):
     def __complex__(self):
         return complex(self.value)
 
-    __index__ = __int__
+    @property
+    def __index__(self):
+        if self.dtype in _index_dtypes:
+            return self.__int__
+        raise AttributeError("Scalar object only has `__index__` for integral dtypes")
 
     def __array__(self, dtype=None):
         if dtype is None:

--- a/graphblas/core/ss/config.py
+++ b/graphblas/core/ss/config.py
@@ -1,10 +1,9 @@
 from collections.abc import MutableMapping
-from numbers import Integral
 
 from ...dtypes import lookup_dtype
 from ...exceptions import _error_code_lookup, check_status
 from .. import NULL, ffi, lib
-from ..utils import values_to_numpy_buffer
+from ..utils import maybe_integral, values_to_numpy_buffer
 
 
 class BaseConfig(MutableMapping):
@@ -147,8 +146,8 @@ class BaseConfig(MutableMapping):
             bitwise = self._bitwise[key]
             if isinstance(val, str):
                 val = bitwise[val.lower()]
-            elif isinstance(val, Integral):
-                val = bitwise.get(val, val)
+            elif (x := maybe_integral(val)) is not None:
+                val = bitwise.get(x, x)
             else:
                 bits = 0
                 for x in val:

--- a/graphblas/dtypes/__init__.py
+++ b/graphblas/dtypes/__init__.py
@@ -41,3 +41,6 @@ def __getattr__(key):
         globals()["ss"] = ss
         return ss
     raise AttributeError(f"module {__name__!r} has no attribute {key!r}")
+
+
+_index_dtypes = {BOOL, INT8, UINT8, INT16, UINT16, INT32, UINT32, INT64, UINT64, _INDEX}

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -132,6 +132,8 @@ def test_casting(s):
     assert float(s) == 5.0
     assert type(float(s)) is float
     assert range(s) == range(5)
+    with pytest.raises(AttributeError, match="Scalar .* only .*__index__.*integral"):
+        range(s.dup(float))
     assert complex(s) == complex(5)
     assert type(complex(s)) is complex
 

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -3,11 +3,11 @@
 # Use, adjust, copy/paste, etc. as necessary to answer your questions.
 # This may be helpful when updating dependency versions in CI.
 # Tip: add `--json` for more information.
-conda search 'numpy[channel=conda-forge]>=1.25.0'
+conda search 'numpy[channel=conda-forge]>=1.25.1'
 conda search 'pandas[channel=conda-forge]>=2.0.3'
 conda search 'scipy[channel=conda-forge]>=1.11.1'
 conda search 'networkx[channel=conda-forge]>=3.1'
-conda search 'awkward[channel=conda-forge]>=2.3.0'
+conda search 'awkward[channel=conda-forge]>=2.3.1'
 conda search 'sparse[channel=conda-forge]>=0.14.0'
 conda search 'fast_matrix_market[channel=conda-forge]>=1.7.2'
 conda search 'numba[channel=conda-forge]>=0.57.1'


### PR DESCRIPTION
I noticed `Scalar.__index__` wasn't quite correct. It should be strict and not work for float dtypes.

Also, update how we check whether inputs are integral or not.

Also, update versions.