### PR TITLE
Add docstrings for using SS JIT, and make better

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ coverage:
         informational: true
     changes: false
 comment:
+  layout: "header, diff, footer"
   behavior: default
 github_checks:
   annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,9 @@ coverage:
       default:
         informational: true
     changes: false
-comment: on
+comment:
+  behavior: default
+github_checks:
+  annotations: false
 ignore:
   - graphblas/viz.py

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,7 @@ coverage:
         informational: true
     changes: false
 comment:
-  layout: "header, diff, footer"
+  layout: "header, diff"
   behavior: default
 github_checks:
   annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,6 @@ coverage:
       default:
         informational: true
     changes: false
-comment: off
+comment: on
 ignore:
   - graphblas/viz.py

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -144,8 +144,7 @@ jobs:
           use-mamba: true
           python-version: ${{ steps.pyver.outputs.selected }}
           channels: conda-forge,${{ contains(steps.pyver.outputs.selected, 'pypy') && 'defaults' || 'nodefaults' }}
-          # mamba does not yet implement strict priority
-          # channel-priority: ${{ contains(steps.pyver.outputs.selected, 'pypy') && 'flexible' || 'strict' }}
+          channel-priority: ${{ contains(steps.pyver.outputs.selected, 'pypy') && 'flexible' || 'strict' }}
           activate-environment: graphblas
           auto-activate-base: false
       - name: Setup conda

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -411,9 +411,6 @@ jobs:
         if: matrix.slowtask == 'pytest_bizarro'
         run: |
           # This step uses `black`
-          if [[ ${{ startsWith(steps.pyver.outputs.selected, '3.12') }} == true ]]; then
-            pip install black  # Latest version of black on conda-forge does not have builds for Python 3.12
-          fi
           coverage run -a -m graphblas.core.automethods
           coverage run -a -m graphblas.core.infixmethods
           git diff --exit-code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.7.0
+    rev: v0.8.0
     hooks:
       - id: sphinx-lint
         args: [--enable, all, "--disable=line-too-long,leaked-markup"]

--- a/graphblas/core/operator/base.py
+++ b/graphblas/core/operator/base.py
@@ -342,9 +342,18 @@ class OpBase:
         dtype = lookup_dtype(type_)
         return self._compile_udt(dtype, dtype)
 
-    def _add(self, op):
-        self._typed_ops[op.type] = op
-        self.types[op.type] = op.return_type
+    def _add(self, op, *, is_jit=False):
+        if is_jit:
+            if hasattr(op, "type2") or hasattr(op, "thunk_type"):
+                dtypes = (op.type, op._type2)
+            else:
+                dtypes = op.type
+            self.types[dtypes] = op.return_type  # This is a different use of .types
+            self._udt_types[dtypes] = op.return_type
+            self._udt_ops[dtypes] = op
+        else:
+            self._typed_ops[op.type] = op
+            self.types[op.type] = op.return_type
 
     def __delitem__(self, type_):
         type_ = lookup_dtype(type_)

--- a/graphblas/core/operator/base.py
+++ b/graphblas/core/operator/base.py
@@ -336,8 +336,6 @@ class OpBase:
                     raise KeyError(f"{self.name} does not work with {type_}")
             else:
                 return self._typed_ops[type_]
-        if not _supports_udfs:
-            raise KeyError(f"{self.name} does not work with {type_}")
         # This is a UDT or is able to operate on UDTs such as `first` any `any`
         dtype = lookup_dtype(type_)
         return self._compile_udt(dtype, dtype)

--- a/graphblas/core/operator/binary.py
+++ b/graphblas/core/operator/binary.py
@@ -523,8 +523,8 @@ class BinaryOp(OpBase):
         if dtypes in self._udt_types:
             return self._udt_ops[dtypes]
 
-        nt = numba.types
-        if self.name == "eq" and not self._anonymous:
+        if self.name == "eq" and not self._anonymous and _has_numba:
+            nt = numba.types
             # assert dtype.np_type == dtype2.np_type
             itemsize = dtype.np_type.itemsize
             mask = _udt_mask(dtype.np_type)
@@ -561,7 +561,8 @@ class BinaryOp(OpBase):
                     #     z_ptr[0] = True
                     z_ptr[0] = (x[mask] == y[mask]).all()
 
-        elif self.name == "ne" and not self._anonymous:
+        elif self.name == "ne" and not self._anonymous and _has_numba:
+            nt = numba.types
             # assert dtype.np_type == dtype2.np_type
             itemsize = dtype.np_type.itemsize
             mask = _udt_mask(dtype.np_type)

--- a/graphblas/core/operator/binary.py
+++ b/graphblas/core/operator/binary.py
@@ -597,6 +597,8 @@ class BinaryOp(OpBase):
                     #     z_ptr[0] = False
                     z_ptr[0] = (x[mask] != y[mask]).any()
 
+        elif self._numba_func is None:
+            raise KeyError(f"{self.name} does not work with {dtypes} types")
         else:
             numba_func = self._numba_func
             sig = (dtype.numba_type, dtype2.numba_type)

--- a/graphblas/core/operator/indexunary.py
+++ b/graphblas/core/operator/indexunary.py
@@ -25,6 +25,10 @@ class TypedBuiltinIndexUnaryOp(TypedOpBase):
             thunk = False  # most basic form of 0 when unifying dtypes
         return _call_op(self, val, right=thunk)
 
+    @property
+    def thunk_type(self):
+        return self.type if self._type2 is None else self._type2
+
 
 class TypedUserIndexUnaryOp(TypedOpBase):
     __slots__ = ()
@@ -41,6 +45,7 @@ class TypedUserIndexUnaryOp(TypedOpBase):
     def _numba_func(self):
         return self.parent._numba_func
 
+    thunk_type = TypedBuiltinIndexUnaryOp.thunk_type
     __call__ = TypedBuiltinIndexUnaryOp.__call__
 
 
@@ -210,6 +215,8 @@ class IndexUnaryOp(OpBase):
         dtypes = (dtype, dtype2)
         if dtypes in self._udt_types:
             return self._udt_ops[dtypes]
+        if self._numba_func is None:
+            raise KeyError(f"{self.name} does not work with {dtypes} types")
 
         numba_func = self._numba_func
         sig = (dtype.numba_type, UINT64.numba_type, UINT64.numba_type, dtype2.numba_type)

--- a/graphblas/core/operator/unary.py
+++ b/graphblas/core/operator/unary.py
@@ -252,6 +252,8 @@ class UnaryOp(OpBase):
     def _compile_udt(self, dtype, dtype2):
         if dtype in self._udt_types:
             return self._udt_ops[dtype]
+        if self._numba_func is None:
+            raise KeyError(f"{self.name} does not work with {dtype}")
 
         numba_func = self._numba_func
         sig = (dtype.numba_type,)

--- a/graphblas/core/ss/indexunary.py
+++ b/graphblas/core/ss/indexunary.py
@@ -21,10 +21,56 @@ class TypedJitIndexUnaryOp(TypedOpBase):
     def jit_c_definition(self):
         return self._jit_c_definition
 
+    thunk_type = TypedUserIndexUnaryOp.thunk_type
     __call__ = TypedUserIndexUnaryOp.__call__
 
 
 def register_new(name, jit_c_definition, input_type, thunk_type, ret_type):
+    """Register a new IndexUnaryOp using the SuiteSparse:GraphBLAS JIT compiler.
+
+    This creates a IndexUnaryOp by compiling the C string definition of the function.
+    It requires a shell call to a C compiler. The resulting operator will be as
+    fast as if it were built-in to SuiteSparse:GraphBLAS and does not have the
+    overhead of additional function calls as when using ``gb.indexunary.register_new``.
+
+    This is an advanced feature that requires a C compiler and proper configuration.
+    Configuration is handled by ``gb.ss.config``; see its docstring for details.
+    By default, the JIT caches results in ``~/.SuiteSparse/``. For more information,
+    see the SuiteSparse:GraphBLAS user guide.
+
+    Only one type signature may be registered at a time, but repeated calls using
+    the same name with different input types is allowed.
+
+    This will also create a SelectOp operator under ``gb.select.ss`` if the return
+    type is boolean.
+
+    Parameters
+    ----------
+    name : str
+        The name of the operator. This will show up as ``gb.indexunary.ss.{name}``.
+        The name may contain periods, ".", which will result in nested objects
+        such as ``gb.indexunary.ss.x.y.z`` for name ``"x.y.z"``.
+    jit_c_definition : str
+        The C definition as a string of the user-defined function. For example:
+        ``"void diffy (double *z, double *x, GrB_Index i, GrB_Index j, double *y) "``
+        ``"{ (*z) = (i + j) * fabs ((*x) - (*y)) ; }"``
+    input_type : dtype
+        The dtype of the operand of the indexunary operator.
+    thunk_type : dtype
+        The dtype of the thunk of the indexunary operator.
+    ret_type : dtype
+        The dtype of the result of the indexunary operator.
+
+    Returns
+    -------
+    IndexUnaryOp
+
+    See Also
+    --------
+    gb.indexunary.register_new
+    gb.indexunary.register_anonymous
+    gb.select.ss.register_new
+    """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(
             "`gb.indexunary.ss.register_new` invalid when not using 'suitesparse' backend"
@@ -41,9 +87,23 @@ def register_new(name, jit_c_definition, input_type, thunk_type, ret_type):
     thunk_type = lookup_dtype(thunk_type)
     ret_type = lookup_dtype(ret_type)
     name = name if name.startswith("ss.") else f"ss.{name}"
-    module, funcname = IndexUnaryOp._remove_nesting(name)
-
-    rv = IndexUnaryOp(name)
+    module, funcname = IndexUnaryOp._remove_nesting(name, strict=False)
+    if hasattr(module, funcname):
+        rv = getattr(module, funcname)
+        if not isinstance(rv, IndexUnaryOp):
+            IndexUnaryOp._remove_nesting(name)
+        if (
+            (input_type, thunk_type) in rv.types
+            or rv._udt_types is not None
+            and (input_type, thunk_type) in rv._udt_types
+        ):
+            raise TypeError(
+                f"IndexUnaryOp gb.indexunary.{name} already defined for "
+                f"({input_type}, {thunk_type}) input types"
+            )
+    else:
+        # We use `is_udt=True` to make dtype handling flexible and explicit.
+        rv = IndexUnaryOp(name, is_udt=True)
     gb_obj = ffi_new("GrB_IndexUnaryOp*")
     check_status_carg(
         lib.GxB_IndexUnaryOp_new(
@@ -61,17 +121,32 @@ def register_new(name, jit_c_definition, input_type, thunk_type, ret_type):
     op = TypedJitIndexUnaryOp(
         rv, funcname, input_type, ret_type, gb_obj[0], jit_c_definition, dtype2=thunk_type
     )
-    rv._add(op)
+    rv._add(op, is_jit=True)
     if ret_type == BOOL:
         from ..operator.select import SelectOp
         from .select import TypedJitSelectOp
 
         select_module, funcname = SelectOp._remove_nesting(name, strict=False)
-        selectop = SelectOp(name)
+        if hasattr(select_module, funcname):
+            selectop = getattr(select_module, funcname)
+            if not isinstance(selectop, SelectOp):
+                SelectOp._remove_nesting(name)
+            if (
+                (input_type, thunk_type) in selectop.types
+                or selectop._udt_types is not None
+                and (input_type, thunk_type) in selectop._udt_types
+            ):
+                raise TypeError(
+                    f"SelectOp gb.select.{name} already defined for "
+                    f"({input_type}, {thunk_type}) input types"
+                )
+        else:
+            # We use `is_udt=True` to make dtype handling flexible and explicit.
+            selectop = SelectOp(name, is_udt=True)
         op2 = TypedJitSelectOp(
-            rv, funcname, input_type, ret_type, gb_obj[0], jit_c_definition, dtype2=thunk_type
+            selectop, funcname, input_type, ret_type, gb_obj[0], jit_c_definition, dtype2=thunk_type
         )
-        selectop._add(op2)
+        selectop._add(op2, is_jit=True)
         setattr(select_module, funcname, selectop)
     setattr(module, funcname, rv)
     return rv

--- a/graphblas/core/ss/select.py
+++ b/graphblas/core/ss/select.py
@@ -20,10 +20,53 @@ class TypedJitSelectOp(TypedOpBase):
     def jit_c_definition(self):
         return self._jit_c_definition
 
+    thunk_type = TypedUserSelectOp.thunk_type
     __call__ = TypedUserSelectOp.__call__
 
 
 def register_new(name, jit_c_definition, input_type, thunk_type):
+    """Register a new SelectOp using the SuiteSparse:GraphBLAS JIT compiler.
+
+    This creates a SelectOp by compiling the C string definition of the function.
+    It requires a shell call to a C compiler. The resulting operator will be as
+    fast as if it were built-in to SuiteSparse:GraphBLAS and does not have the
+    overhead of additional function calls as when using ``gb.select.register_new``.
+
+    This is an advanced feature that requires a C compiler and proper configuration.
+    Configuration is handled by ``gb.ss.config``; see its docstring for details.
+    By default, the JIT caches results in ``~/.SuiteSparse/``. For more information,
+    see the SuiteSparse:GraphBLAS user guide.
+
+    Only one type signature may be registered at a time, but repeated calls using
+    the same name with different input types is allowed.
+
+    This will also create an IndexUnary operator under ``gb.indexunary.ss``
+
+    Parameters
+    ----------
+    name : str
+        The name of the operator. This will show up as ``gb.select.ss.{name}``.
+        The name may contain periods, ".", which will result in nested objects
+        such as ``gb.select.ss.x.y.z`` for name ``"x.y.z"``.
+    jit_c_definition : str
+        The C definition as a string of the user-defined function. For example:
+        ``"void woot (bool *z, const int32_t *x, GrB_Index i, GrB_Index j, int32_t *y) "``
+        ``"{ (*z) = ((*x) + i + j == (*y)) ; }"``
+    input_type : dtype
+        The dtype of the operand of the select operator.
+    thunk_type : dtype
+        The dtype of the thunk of the select operator.
+
+    Returns
+    -------
+    SelectOp
+
+    See Also
+    --------
+    gb.select.register_new
+    gb.select.register_anonymous
+    gb.indexunary.ss.register_new
+    """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(
             "`gb.select.ss.register_new` invalid when not using 'suitesparse' backend"

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -19,7 +19,7 @@ from graphblas import (
 )
 from graphblas.core import _supports_udfs as supports_udfs
 from graphblas.core import lib, operator
-from graphblas.core.operator import BinaryOp, IndexUnaryOp, Monoid, Semiring, UnaryOp, get_semiring
+from graphblas.core.operator import BinaryOp, IndexUnaryOp, Monoid, Semiring, UnaryOp, get_semiring, SelectOp
 from graphblas.dtypes import (
     BOOL,
     FP32,
@@ -1335,6 +1335,19 @@ def test_udt():
     assert binary.first[udt, dtypes.INT8].type is udt
     assert binary.first[udt, dtypes.INT8].type2 is dtypes.INT8
     assert monoid.any[udt].type2 is udt
+
+    def _this_or_that(val, idx, _, thunk):  # pragma: no cover (numba)
+        return val["x"]
+
+    sel = SelectOp.register_anonymous(_this_or_that, is_udt=True)
+    sel[udt]
+    assert udt in sel
+    result = v.select(sel, 0).new()
+    assert result.nvals == 0
+    assert result.dtype == v.dtype
+    result = w.select(sel, 0).new()
+    assert result.nvals == 3
+    assert result.isequal(w)
 
 
 def test_dir():

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -19,7 +19,15 @@ from graphblas import (
 )
 from graphblas.core import _supports_udfs as supports_udfs
 from graphblas.core import lib, operator
-from graphblas.core.operator import BinaryOp, IndexUnaryOp, Monoid, Semiring, UnaryOp, get_semiring, SelectOp
+from graphblas.core.operator import (
+    BinaryOp,
+    IndexUnaryOp,
+    Monoid,
+    SelectOp,
+    Semiring,
+    UnaryOp,
+    get_semiring,
+)
 from graphblas.dtypes import (
     BOOL,
     FP32,


### PR DESCRIPTION
Also:
- allow a SS JIT function to be registered under the same name with different input types
- be extra-strict about input types for SS JIT
- test numba JIT with select with udt

CC @michelp in case you want to look at the docstrings and signatures of our functions for using SuiteSparse:GraphBLAS JIT such as `gb.binary.ss.register_new`--I think you're the most likely to show off something cool using the JIT ;)
(also, let me know if you want help using the JIT locally).

I think we should cut a new release after this is merged.