### PR TITLE
Add `gb.ss.burble` from python-suitesparse-graphblas

### DIFF
--- a/graphblas/ss/__init__.py
+++ b/graphblas/ss/__init__.py
@@ -1,3 +1,5 @@
+from suitesparse_graphblas import burble
+
 from ._core import _IS_SSGB7, about, concat, config, diag
 
 if not _IS_SSGB7:


### PR DESCRIPTION
The SuiteSparse:GraphBLAS burble can be pretty handy, and having a burble object makes it as easy to use as possible. We reuse `burble` from python-suitesparse-graphblas (added last year), which is already pretty capable:
https://github.com/GraphBLAS/python-suitesparse-graphblas/blob/decaf1502d1a6053ba7b829e61b5ed796139ff2a/suitesparse_graphblas/__init__.py#L223
Note that one can still interact with the burble via config option such as
```python
gb.ss.config["burble"] = True
```
but sometimes you just want to do
```python
with gb.ss.burble:
    ...
```
FYI @michelp