### PR TITLE
Add `gb.MAX_SIZE`, which is `GrB_INDEX_MAX + 1`

### DIFF
--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -39,6 +39,7 @@ del get_config
 backend = None
 _init_params = None
 _SPECIAL_ATTRS = {
+    "INDEX_MAX",
     "Matrix",
     "Recorder",
     "Scalar",
@@ -205,6 +206,10 @@ def _load(name):
     if name in {"Matrix", "Vector", "Scalar", "Recorder"}:
         module = _import_module(f".core.{name.lower()}", __name__)
         globals()[name] = getattr(module, name)
+    elif name == "INDEX_MAX":
+        from .core import lib
+
+        globals()[name] = lib.GrB_INDEX_MAX
     else:
         # Everything else is a module
         globals()[name] = _import_module(f".{name}", __name__)

--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -39,7 +39,7 @@ del get_config
 backend = None
 _init_params = None
 _SPECIAL_ATTRS = {
-    "MAX_SIZE",
+    "MAX_SIZE",  # The maximum size of Vector and Matrix dimensions (GrB_INDEX_MAX + 1)
     "Matrix",
     "Recorder",
     "Scalar",

--- a/graphblas/__init__.py
+++ b/graphblas/__init__.py
@@ -39,7 +39,7 @@ del get_config
 backend = None
 _init_params = None
 _SPECIAL_ATTRS = {
-    "INDEX_MAX",
+    "MAX_SIZE",
     "Matrix",
     "Recorder",
     "Scalar",
@@ -206,10 +206,10 @@ def _load(name):
     if name in {"Matrix", "Vector", "Scalar", "Recorder"}:
         module = _import_module(f".core.{name.lower()}", __name__)
         globals()[name] = getattr(module, name)
-    elif name == "INDEX_MAX":
+    elif name == "MAX_SIZE":
         from .core import lib
 
-        globals()[name] = lib.GrB_INDEX_MAX
+        globals()[name] = lib.GrB_INDEX_MAX + 1
     else:
         # Everything else is a module
         globals()[name] = _import_module(f".{name}", __name__)

--- a/graphblas/tests/test_core.py
+++ b/graphblas/tests/test_core.py
@@ -90,3 +90,7 @@ def test_packages():
     assert (
         pkgs == pkgs2
     ), "If there are extra items on the left, add them to pyproject.toml:tool.setuptools.packages"
+
+
+def test_index_max():
+    assert gb.INDEX_MAX == 2**60 - 1  # True for all current backends

--- a/graphblas/tests/test_core.py
+++ b/graphblas/tests/test_core.py
@@ -93,4 +93,4 @@ def test_packages():
 
 
 def test_index_max():
-    assert gb.INDEX_MAX == 2**60 - 1  # True for all current backends
+    assert gb.MAX_SIZE == 2**60  # True for all current backends

--- a/scripts/test_imports.sh
+++ b/scripts/test_imports.sh
@@ -13,7 +13,7 @@ if ! python -c "from graphblas.select import tril" ; then exit 1 ; fi
 if ! python -c "from graphblas.semiring import plus_times" ; then exit 1 ; fi
 if ! python -c "from graphblas.unary import exp" ; then exit 1 ; fi
 if ! (for attr in Matrix Scalar Vector Recorder agg binary dtypes exceptions \
-  init io monoid op select semiring tests unary ss viz INDEX_MAX
+  init io monoid op select semiring tests unary ss viz MAX_SIZE
   do echo python -c \"from graphblas import $attr\"
     if ! python -c "from graphblas import $attr"
       then exit 1

--- a/scripts/test_imports.sh
+++ b/scripts/test_imports.sh
@@ -13,7 +13,7 @@ if ! python -c "from graphblas.select import tril" ; then exit 1 ; fi
 if ! python -c "from graphblas.semiring import plus_times" ; then exit 1 ; fi
 if ! python -c "from graphblas.unary import exp" ; then exit 1 ; fi
 if ! (for attr in Matrix Scalar Vector Recorder agg binary dtypes exceptions \
-  init io monoid op select semiring tests unary ss viz
+  init io monoid op select semiring tests unary ss viz INDEX_MAX
   do echo python -c \"from graphblas import $attr\"
     if ! python -c "from graphblas import $attr"
       then exit 1


### PR DESCRIPTION
`INDEX_MAX` may be a nice global value to expose. The GraphBLAS spec doesn't have many of these globals.

This is the largest index value, not the size of the domain of indices. For example, create the largest vector via `Vector(int, INDEX_MAX + 1)`. Also, note that the spec does not specify a value for `GrB_INDEX_MAX`, only that implementations define it, so it may be backend-dependent.

Alternatively, we could instead define `MAX_SIZE`, which would be `GrB_INDEX_MAX + 1`. I think this is much more natural to use; e.g., `Matrix(int, MAX_SIZE, MAX_SIZE)`. I don't think we need both `INDEX_MAX` and `MAX_SIZE`.

So, which to y'all prefer, `INDEX_MAX` or `MAX_SIZE`? Feel free to suggest different names too. 
CC @michelp @jim22k @SultanOrazbayev