### PR TITLE
Remove deprecated `to_values` and `from_values`.

### DIFF
--- a/graphblas/core/automethods.py
+++ b/graphblas/core/automethods.py
@@ -281,10 +281,6 @@ def to_edgelist(self):
     return self._get_value("to_edgelist")
 
 
-def to_values(self):
-    return self._get_value("to_values")
-
-
 def value(self):
     return self._get_value("value")
 
@@ -398,7 +394,6 @@ def _main():
         "ss",
         "to_coo",
         "to_dense",
-        "to_values",
     }
     vector = {
         "_as_matrix",

--- a/graphblas/core/infix.py
+++ b/graphblas/core/infix.py
@@ -236,7 +236,6 @@ class VectorInfixExpr(InfixExprBase):
     to_coo = wrapdoc(Vector.to_coo)(property(automethods.to_coo))
     to_dense = wrapdoc(Vector.to_dense)(property(automethods.to_dense))
     to_dict = wrapdoc(Vector.to_dict)(property(automethods.to_dict))
-    to_values = wrapdoc(Vector.to_values)(property(automethods.to_values))
     vxm = wrapdoc(Vector.vxm)(property(automethods.vxm))
     wait = wrapdoc(Vector.wait)(property(automethods.wait))
     # These raise exceptions
@@ -396,7 +395,6 @@ class MatrixInfixExpr(InfixExprBase):
     to_dense = wrapdoc(Matrix.to_dense)(property(automethods.to_dense))
     to_dicts = wrapdoc(Matrix.to_dicts)(property(automethods.to_dicts))
     to_edgelist = wrapdoc(Matrix.to_edgelist)(property(automethods.to_edgelist))
-    to_values = wrapdoc(Matrix.to_values)(property(automethods.to_values))
     wait = wrapdoc(Matrix.wait)(property(automethods.wait))
     # These raise exceptions
     __array__ = Matrix.__array__

--- a/graphblas/core/matrix.py
+++ b/graphblas/core/matrix.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -515,42 +514,6 @@ class Matrix(BaseType):
         self._nrows = nrows.value
         self._ncols = ncols.value
 
-    def to_values(self, dtype=None, *, rows=True, columns=True, values=True, sort=True):
-        """Extract the indices and values as a 3-tuple of numpy arrays
-        corresponding to the COO format of the Matrix.
-
-        .. deprecated:: 2022.11.0
-            ``Matrix.to_values`` will be removed in a future release.
-            Use ``Matrix.to_coo`` instead. Will be removed in version 2023.9.0 or later
-
-        Parameters
-        ----------
-        dtype :
-            Requested dtype for the output values array.
-        rows : bool, default=True
-            Whether to return rows; will return ``None`` for rows if ``False``
-        columns : bool, default=True
-            Whether to return columns; will return ``None`` for columns if ``False``
-        values : bool, default=True
-            Whether to return values; will return ``None`` for values if ``False``
-        sort : bool, default=True
-            Whether to require sorted indices.
-            If internally stored rowwise, the sorting will be first by rows, then by column.
-            If internally stored columnwise, the sorting will be first by column, then by row.
-
-        Returns
-        -------
-        np.ndarray[dtype=uint64] : Rows
-        np.ndarray[dtype=uint64] : Columns
-        np.ndarray : Values
-        """
-        warnings.warn(
-            "`Matrix.to_values(...)` is deprecated; please use `Matrix.to_coo(...)` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.to_coo(dtype, rows=rows, columns=columns, values=values, sort=sort)
-
     def to_coo(self, dtype=None, *, rows=True, columns=True, values=True, sort=True):
         """Extract the indices and values as a 3-tuple of numpy arrays
         corresponding to the COO format of the Matrix.
@@ -835,61 +798,6 @@ class Matrix(BaseType):
         raise ValueError(
             "Bad row, col arguments in Matrix.get(...).  "
             "Indices should get a single element, which will be extracted as a Python scalar."
-        )
-
-    @classmethod
-    def from_values(
-        cls,
-        rows,
-        columns,
-        values,
-        dtype=None,
-        *,
-        nrows=None,
-        ncols=None,
-        dup_op=None,
-        name=None,
-    ):
-        """Create a new Matrix from row and column indices and values.
-
-        .. deprecated:: 2022.11.0
-            ``Matrix.from_values`` will be removed in a future release.
-            Use ``Matrix.from_coo`` instead. Will be removed in version 2023.9.0 or later
-
-        Parameters
-        ----------
-        rows : list or np.ndarray
-            Row indices.
-        columns : list or np.ndarray
-            Column indices.
-        values : list or np.ndarray or scalar
-            List of values. If a scalar is provided, all values will be set to this single value.
-        dtype :
-            Data type of the Matrix. If not provided, the values will be inspected
-            to choose an appropriate dtype.
-        nrows : int, optional
-            Number of rows in the Matrix. If not provided, ``nrows`` is computed
-            from the maximum row index found in ``rows``.
-        ncols : int, optional
-            Number of columns in the Matrix. If not provided, ``ncols`` is computed
-            from the maximum column index found in ``columns``.
-        dup_op : :class:`~graphblas.core.operator.BinaryOp`, optional
-            Function used to combine values if duplicate indices are found.
-            Leaving ``dup_op=None`` will raise an error if duplicates are found.
-        name : str, optional
-            Name to give the Matrix.
-
-        Returns
-        -------
-        Matrix
-        """
-        warnings.warn(
-            "`Matrix.from_values(...)` is deprecated; please use `Matrix.from_coo(...)` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls.from_coo(
-            rows, columns, values, dtype, nrows=nrows, ncols=ncols, dup_op=dup_op, name=name
         )
 
     @classmethod
@@ -3751,7 +3659,6 @@ class MatrixExpression(BaseExpression):
     to_dense = wrapdoc(Matrix.to_dense)(property(automethods.to_dense))
     to_dicts = wrapdoc(Matrix.to_dicts)(property(automethods.to_dicts))
     to_edgelist = wrapdoc(Matrix.to_edgelist)(property(automethods.to_edgelist))
-    to_values = wrapdoc(Matrix.to_values)(property(automethods.to_values))
     wait = wrapdoc(Matrix.wait)(property(automethods.wait))
     # These raise exceptions
     __array__ = Matrix.__array__
@@ -3852,7 +3759,6 @@ class MatrixIndexExpr(AmbiguousAssignOrExtract):
     to_dense = wrapdoc(Matrix.to_dense)(property(automethods.to_dense))
     to_dicts = wrapdoc(Matrix.to_dicts)(property(automethods.to_dicts))
     to_edgelist = wrapdoc(Matrix.to_edgelist)(property(automethods.to_edgelist))
-    to_values = wrapdoc(Matrix.to_values)(property(automethods.to_values))
     wait = wrapdoc(Matrix.wait)(property(automethods.wait))
     # These raise exceptions
     __array__ = Matrix.__array__
@@ -3923,13 +3829,6 @@ class TransposedMatrix:
     @wrapdoc(Matrix.to_coo)
     def to_coo(self, dtype=None, *, rows=True, columns=True, values=True, sort=True):
         rows, cols, vals = self._matrix.to_coo(
-            dtype, rows=rows, columns=columns, values=values, sort=sort
-        )
-        return cols, rows, vals
-
-    @wrapdoc(Matrix.to_values)
-    def to_values(self, dtype=None, *, rows=True, columns=True, values=True, sort=True):
-        rows, cols, vals = self._matrix.to_values(
             dtype, rows=rows, columns=columns, values=values, sort=sort
         )
         return cols, rows, vals

--- a/graphblas/core/vector.py
+++ b/graphblas/core/vector.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 
 import numpy as np
 
@@ -456,36 +455,6 @@ class Vector(BaseType):
         call("GrB_Vector_resize", [self, size])
         self._size = size.value
 
-    def to_values(self, dtype=None, *, indices=True, values=True, sort=True):
-        """Extract the indices and values as a 2-tuple of numpy arrays.
-
-        .. deprecated:: 2022.11.0
-            ``Vector.to_values`` will be removed in a future release.
-            Use ``Vector.to_coo`` instead. Will be removed in version 2023.9.0 or later
-
-        Parameters
-        ----------
-        dtype :
-            Requested dtype for the output values array.
-        indices :bool, default=True
-            Whether to return indices; will return ``None`` for indices if ``False``
-        values : bool, default=True
-            Whether to return values; will return ``None`` for values if ``False``
-        sort : bool, default=True
-            Whether to require sorted indices.
-
-        Returns
-        -------
-        np.ndarray[dtype=uint64] : Indices
-        np.ndarray : Values
-        """
-        warnings.warn(
-            "`Vector.to_values(...)` is deprecated; please use `Vector.to_coo(...)` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.to_coo(dtype, indices=indices, values=values, sort=sort)
-
     def to_coo(self, dtype=None, *, indices=True, values=True, sort=True):
         """Extract the indices and values as a 2-tuple of numpy arrays.
 
@@ -696,43 +665,6 @@ class Vector(BaseType):
             "Bad index in Vector.get(...).  "
             "A single index should be given, and the result will be a Python scalar."
         )
-
-    @classmethod
-    def from_values(cls, indices, values, dtype=None, *, size=None, dup_op=None, name=None):
-        """Create a new Vector from indices and values.
-
-        .. deprecated:: 2022.11.0
-            ``Vector.from_values`` will be removed in a future release.
-            Use ``Vector.from_coo`` instead. Will be removed in version 2023.9.0 or later
-
-        Parameters
-        ----------
-        indices : list or np.ndarray
-            Vector indices.
-        values : list or np.ndarray or scalar
-            List of values. If a scalar is provided, all values will be set to this single value.
-        dtype :
-            Data type of the Vector. If not provided, the values will be inspected
-            to choose an appropriate dtype.
-        size : int, optional
-            Size of the Vector. If not provided, ``size`` is computed from
-            the maximum index found in ``indices``.
-        dup_op : BinaryOp, optional
-            Function used to combine values if duplicate indices are found.
-            Leaving ``dup_op=None`` will raise an error if duplicates are found.
-        name : str, optional
-            Name to give the Vector.
-
-        Returns
-        -------
-        Vector
-        """
-        warnings.warn(
-            "`Vector.from_values(...)` is deprecated; please use `Vector.from_coo(...)` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls.from_coo(indices, values, dtype, size=size, dup_op=dup_op, name=name)
 
     @classmethod
     def from_coo(cls, indices, values=1.0, dtype=None, *, size=None, dup_op=None, name=None):
@@ -2271,7 +2203,6 @@ class VectorExpression(BaseExpression):
     to_coo = wrapdoc(Vector.to_coo)(property(automethods.to_coo))
     to_dense = wrapdoc(Vector.to_dense)(property(automethods.to_dense))
     to_dict = wrapdoc(Vector.to_dict)(property(automethods.to_dict))
-    to_values = wrapdoc(Vector.to_values)(property(automethods.to_values))
     vxm = wrapdoc(Vector.vxm)(property(automethods.vxm))
     wait = wrapdoc(Vector.wait)(property(automethods.wait))
     # These raise exceptions
@@ -2359,7 +2290,6 @@ class VectorIndexExpr(AmbiguousAssignOrExtract):
     to_coo = wrapdoc(Vector.to_coo)(property(automethods.to_coo))
     to_dense = wrapdoc(Vector.to_dense)(property(automethods.to_dense))
     to_dict = wrapdoc(Vector.to_dict)(property(automethods.to_dict))
-    to_values = wrapdoc(Vector.to_values)(property(automethods.to_values))
     vxm = wrapdoc(Vector.vxm)(property(automethods.vxm))
     wait = wrapdoc(Vector.wait)(property(automethods.wait))
     # These raise exceptions

--- a/graphblas/tests/test_matrix.py
+++ b/graphblas/tests/test_matrix.py
@@ -2952,7 +2952,6 @@ def test_expr_is_like_matrix(A):
         "from_dicts",
         "from_edgelist",
         "from_scalar",
-        "from_values",
         "resize",
         "setdiag",
         "update",
@@ -3018,7 +3017,6 @@ def test_index_expr_is_like_matrix(A):
         "from_dicts",
         "from_edgelist",
         "from_scalar",
-        "from_values",
         "resize",
         "setdiag",
     }
@@ -3555,15 +3553,6 @@ def test_ss_compactify(A, do_iso):
     assert B.isequal(expected)
     with pytest.raises(ValueError, match="`how` argument must be one of:"):
         A.ss.compactify("bad_how")
-
-
-def test_deprecated(A):
-    with pytest.warns(DeprecationWarning):
-        A.to_values()
-    with pytest.warns(DeprecationWarning):
-        A.T.to_values()
-    with pytest.warns(DeprecationWarning):
-        A.from_values([1], [2], [3])
 
 
 def test_ndim(A):

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -1675,7 +1675,6 @@ def test_expr_is_like_vector(v):
         "from_dict",
         "from_pairs",
         "from_scalar",
-        "from_values",
         "resize",
         "update",
     }
@@ -1725,7 +1724,6 @@ def test_index_expr_is_like_vector(v):
         "from_dict",
         "from_pairs",
         "from_scalar",
-        "from_values",
         "resize",
     }
     ignore = {"__sizeof__", "_ewise_add", "_ewise_mult", "_ewise_union", "_inner", "_vxm"}
@@ -2010,13 +2008,6 @@ def test_ss_split(v):
     assert x2.isequal(expected2)
     assert x1.name == "split_0"
     assert x2.name == "split_1"
-
-
-def test_deprecated(v):
-    with pytest.warns(DeprecationWarning):
-        v.to_values()
-    with pytest.warns(DeprecationWarning):
-        Vector.from_values([1], [2])
 
 
 def test_ndim(A, v):


### PR DESCRIPTION
These have been deprecated since 2022-11-16, so it's been over a year. We wanted to give these a longer deprecation cycle to allow people to swith to `to_coo` and `from_coo`, but I think it's time to clean up.