### PR TITLE
Update to numba 0.59 and other version updates

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -167,7 +167,6 @@ jobs:
           # First let's randomly get versions of dependencies to install.
           # Consider removing old versions when they become problematic or very old (>=2 years).
           nxver=$(python -c 'import random ; print(random.choice(["=2.7", "=2.8", "=3.0", "=3.1", "=3.2", ""]))')
-          yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
           sparsever=$(python -c 'import random ; print(random.choice(["=0.13", "=0.14", "=0.15", ""]))')
           # Randomly choosing versions of dependencies based on Python version works surprisingly well...
           if [[ ${{ startsWith(steps.pyver.outputs.selected, '3.9') }} == true ]]; then
@@ -176,24 +175,28 @@ jobs:
             pdver=$(python -c 'import random ; print(random.choice(["=1.2", "=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
             fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
+            yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.10') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
             fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
+            yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.11') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.23", "=1.24", "=1.25", "=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
             fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
+            yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
           else  # Python 3.12
             npver=$(python -c 'import random ; print(random.choice(["=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=2.4", "=2.5", ""]))')
             fmmver=$(python -c 'import random ; print(random.choice(["=1.7", ""]))')
+            yamlver=$(python -c 'import random ; print(random.choice(["=6.0", ""]))')
           fi
           # But there may be edge cases of incompatibility we need to handle (more handled below)
           if [[ ${{ steps.sourcetype.outputs.selected }} == "source" || ${{ steps.sourcetype.outputs.selected }} == "upstream" ]]; then

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -168,34 +168,31 @@ jobs:
           # Consider removing old versions when they become problematic or very old (>=2 years).
           nxver=$(python -c 'import random ; print(random.choice(["=2.7", "=2.8", "=3.0", "=3.1", "=3.2", ""]))')
           yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
-          sparsever=$(python -c 'import random ; print(random.choice(["=0.13", "=0.14", ""]))')
+          sparsever=$(python -c 'import random ; print(random.choice(["=0.13", "=0.14", "=0.15", ""]))')
           fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
           # Randomly choosing versions of dependencies based on Python version works surprisingly well...
           if [[ ${{ startsWith(steps.pyver.outputs.selected, '3.9') }} == true ]]; then
-            npver=$(python -c 'import random ; print(random.choice(["=1.21", "=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
-            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", ""]))')
-            pdver=$(python -c 'import random ; print(random.choice(["=1.2", "=1.3", "=1.4", "=1.5", "=2.0", "=2.1", ""]))')
+            npver=$(python -c 'import random ; print(random.choice(["=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
+            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
+            pdver=$(python -c 'import random ; print(random.choice(["=1.2", "=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.10') }} == true ]]; then
-            npver=$(python -c 'import random ; print(random.choice(["=1.21", "=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
-            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", ""]))')
-            pdver=$(python -c 'import random ; print(random.choice(["=1.3", "=1.4", "=1.5", "=2.0", "=2.1", ""]))')
+            npver=$(python -c 'import random ; print(random.choice(["=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
+            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
+            pdver=$(python -c 'import random ; print(random.choice(["=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.11') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.23", "=1.24", "=1.25", "=1.26", ""]))')
-            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", ""]))')
-            pdver=$(python -c 'import random ; print(random.choice(["=1.5", "=2.0", "=2.1", ""]))')
+            spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
+            pdver=$(python -c 'import random ; print(random.choice(["=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
           else  # Python 3.12
             npver=$(python -c 'import random ; print(random.choice(["=1.26", ""]))')
-            spver=$(python -c 'import random ; print(random.choice(["=1.11", ""]))')
-            pdver=$(python -c 'import random ; print(random.choice(["=2.1", ""]))')
+            spver=$(python -c 'import random ; print(random.choice(["=1.11", "=1.12", ""]))')
+            pdver=$(python -c 'import random ; print(random.choice(["=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=2.4", "=2.5", ""]))')
           fi
           # But there may be edge cases of incompatibility we need to handle (more handled below)
-          if [[ ${pdver} == "=2.1" && ${npver} == "=1.21" ]]; then
-            pdver="=2.0"
-          fi
           if [[ ${{ steps.sourcetype.outputs.selected }} == "source" || ${{ steps.sourcetype.outputs.selected }} == "upstream" ]]; then
             # TODO: there are currently issues with some numpy versions when
             # installing python-suitesparse-grphblas from source or upstream.
@@ -226,28 +223,28 @@ jobs:
             psgver=$(python -c 'import random ; print(random.choice(["==7.4.0.0", "==7.4.1.0", "==7.4.2.0", "==7.4.3.0", "==7.4.3.1", "==7.4.3.2", "==8.0.2.1", "==8.2.0.1", "==8.2.1.0", ""]))')
           fi
           if [[ ${npver} == "=1.26" ]] ; then
-            numbaver=""
+            numbaver=$(python -c 'import random ; print(random.choice(["=0.58", "=0.59", ""]))')
             if [[ ${spver} == "=1.9" ]] ; then
               spver=$(python -c 'import random ; print(random.choice(["=1.10", "=1.11", ""]))')
             fi
           elif [[ ${npver} == "=1.25" ]] ; then
-            numbaver=""
+            numbaver=$(python -c 'import random ; print(random.choice(["=0.58", "=0.59", ""]))')
           elif [[ ${npver} == "=1.24" || ${{ startsWith(steps.pyver.outputs.selected, '3.11') }} == true ]] ; then
-            numbaver=$(python -c 'import random ; print(random.choice(["=0.57", "=0.58", ""]))')
+            numbaver=$(python -c 'import random ; print(random.choice(["=0.57", "=0.58", "=0.59", ""]))')
           elif [[ ${npver} == "=1.21" ]] ; then
             numbaver=$(python -c 'import random ; print(random.choice(["=0.55", "=0.56", "=0.57", ""]))')
           else
-            numbaver=$(python -c 'import random ; print(random.choice(["=0.56", "=0.57", "=0.58", ""]))')
+            numbaver=$(python -c 'import random ; print(random.choice(["=0.56", "=0.57", "=0.58", "=0.59", ""]))')
           fi
           fmm=fast_matrix_market${fmmver}
           awkward=awkward${akver}
           if [[ ${{ contains(steps.pyver.outputs.selected, 'pypy') ||
-                startsWith(steps.pyver.outputs.selected, '3.12') }} == true ||
+                startsWith(steps.pyver.outputs.selected, '3.13') }} == true ||
                 ( ${{ matrix.slowtask != 'notebooks'}} == true && (
                   ( ${{ matrix.os == 'windows-latest' }} == true && $(python -c 'import random ; print(random.random() < .2)') == True ) ||
                   ( ${{ matrix.os == 'windows-latest' }} == false && $(python -c 'import random ; print(random.random() < .4)') == True ))) ]]
           then
-            # Some packages aren't available for pypy or Python 3.12; randomly otherwise (if not running notebooks)
+            # Some packages aren't available for pypy or Python 3.13; randomly otherwise (if not running notebooks)
             echo "skipping numba"
             numba=""
             numbaver=NA
@@ -264,7 +261,7 @@ jobs:
               pdver=""
               yamlver=""
             fi
-          elif [[ ${npver} == "=1.25" || ${npver} == "=1.26" ]] ; then
+          elif [[ ${npver} == "=2.0" ]] ; then
             # Don't install numba for unsupported versions of numpy
             numba=""
             numbaver=NA

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -239,6 +239,10 @@ jobs:
           else
             numbaver=$(python -c 'import random ; print(random.choice(["=0.56", "=0.57", "=0.58", "=0.59", ""]))')
           fi
+          # Only numba 0.59 support Python 3.12
+          if [[ ${{ startsWith(steps.pyver.outputs.selected, '3.12') }} == true ]] ; then
+            numbaver=$(python -c 'import random ; print(random.choice(["=0.59", ""]))')
+          fi
           fmm=fast_matrix_market${fmmver}
           awkward=awkward${akver}
           if [[ ${{ contains(steps.pyver.outputs.selected, 'pypy') ||

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -91,7 +91,7 @@ jobs:
       # since we need to run all slow tests on Windows and non-Windoes OSes.
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks"]
+        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks",]
     env:
       # Wheels on OS X come with an OpenMP that conflicts with OpenMP from conda-forge.
       # Setting this is a workaround.

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       # To "stress test" in CI, set `fail-fast` to `false` and perhaps add more items to `matrix.slowtask`
-      fail-fast: true
+      fail-fast: false
       # The build matrix is [os]x[slowtask] and then randomly chooses [pyver] and [sourcetype].
       # This should ensure we'll have full code coverage (i.e., no chance of getting unlucky),
       # since we need to run all slow tests on Windows and non-Windoes OSes.
@@ -169,28 +169,31 @@ jobs:
           nxver=$(python -c 'import random ; print(random.choice(["=2.7", "=2.8", "=3.0", "=3.1", "=3.2", ""]))')
           yamlver=$(python -c 'import random ; print(random.choice(["=5.4", "=6.0", ""]))')
           sparsever=$(python -c 'import random ; print(random.choice(["=0.13", "=0.14", "=0.15", ""]))')
-          fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
           # Randomly choosing versions of dependencies based on Python version works surprisingly well...
           if [[ ${{ startsWith(steps.pyver.outputs.selected, '3.9') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=1.2", "=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
+            fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.10') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.22", "=1.23", "=1.24", "=1.25", "=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=1.3", "=1.4", "=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
+            fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
           elif [[ ${{ startsWith(steps.pyver.outputs.selected, '3.11') }} == true ]]; then
             npver=$(python -c 'import random ; print(random.choice(["=1.23", "=1.24", "=1.25", "=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.9", "=1.10", "=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=1.5", "=2.0", "=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=1.10", "=2.0", "=2.1", "=2.2", "=2.3", "=2.4", "=2.5", ""]))')
+            fmmver=$(python -c 'import random ; print(random.choice(["=1.4", "=1.5", "=1.6", "=1.7", ""]))')
           else  # Python 3.12
             npver=$(python -c 'import random ; print(random.choice(["=1.26", ""]))')
             spver=$(python -c 'import random ; print(random.choice(["=1.11", "=1.12", ""]))')
             pdver=$(python -c 'import random ; print(random.choice(["=2.1", "=2.2", ""]))')
             akver=$(python -c 'import random ; print(random.choice(["=2.4", "=2.5", ""]))')
+            fmmver=$(python -c 'import random ; print(random.choice(["=1.7", ""]))')
           fi
           # But there may be edge cases of incompatibility we need to handle (more handled below)
           if [[ ${{ steps.sourcetype.outputs.selected }} == "source" || ${{ steps.sourcetype.outputs.selected }} == "upstream" ]]; then

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -90,8 +90,8 @@ jobs:
       # This should ensure we'll have full code coverage (i.e., no chance of getting unlucky),
       # since we need to run all slow tests on Windows and non-Windoes OSes.
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks",]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest", "ubuntu-latest", "macos-latest", "windows-latest", "ubuntu-latest", "macos-latest", "windows-latest"]
+        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks"]
     env:
       # Wheels on OS X come with an OpenMP that conflicts with OpenMP from conda-forge.
       # Setting this is a workaround.
@@ -316,9 +316,10 @@ jobs:
       - name: python-suitesparse-graphblas tests
         run: |
           # Don't use our conftest.py ; allow `test_print_jit_config` to fail if it doesn't exist
-          (cd ..
-           pytest --pyargs suitesparse_graphblas -s -k test_print_jit_config || true
-           pytest -v --pyargs suitesparse_graphblas)
+          echo el barto
+          # (cd ..
+          #  pytest --pyargs suitesparse_graphblas -s -k test_print_jit_config || true
+          #  pytest -v --pyargs suitesparse_graphblas)
       - name: Unit tests
         run: |
           A=${{ needs.rngs.outputs.mapnumpy == 'A' || '' }} ; B=${{ needs.rngs.outputs.mapnumpy == 'B' || '' }}
@@ -347,8 +348,9 @@ jobs:
             if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)
           echo ${args}
           set -x  # echo on
-          coverage run -m pytest --color=yes --randomly -v ${args} \
-            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
+          echo el barto
+          # coverage run -m pytest --color=yes --randomly -v ${args} \
+          #   ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
@@ -383,8 +385,9 @@ jobs:
             if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)
           echo ${args}
           set -x  # echo on
-          coverage run -a -m pytest --color=yes --randomly -v ${args} \
-            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
+          echo el barto
+          # coverage run -a -m pytest --color=yes --randomly -v ${args} \
+          #   ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
         if: matrix.slowtask == 'pytest_normal'
@@ -413,9 +416,10 @@ jobs:
         if: matrix.slowtask == 'notebooks' && matrix.os == 'windows-latest'
         run: |
           # We use 'notebooks' slow task b/c it should have numba installed
-          coverage run -a -m pytest --color=yes --runslow --no-mapnumpy -p no:randomly -v -k 'test_commutes or test_bool_doesnt_get_too_large or test_npbinary or test_npmonoid or test_npsemiring'
-          coverage run -a -m pytest --color=yes --runslow --mapnumpy -p no:randomly -k 'test_bool_doesnt_get_too_large or test_npunary or test_binaryop_monoid_numpy'
-          coverage run -a -m pytest --color=yes -x --no-mapnumpy --runslow -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
+          echo el barto
+          # coverage run -a -m pytest --color=yes --runslow --no-mapnumpy -p no:randomly -v -k 'test_commutes or test_bool_doesnt_get_too_large or test_npbinary or test_npmonoid or test_npsemiring'
+          # coverage run -a -m pytest --color=yes --runslow --mapnumpy -p no:randomly -k 'test_bool_doesnt_get_too_large or test_npunary or test_binaryop_monoid_numpy'
+          # coverage run -a -m pytest --color=yes -x --no-mapnumpy --runslow -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
       - name: Auto-generated code check
         if: matrix.slowtask == 'pytest_bizarro'
         run: |
@@ -433,6 +437,7 @@ jobs:
         if: matrix.slowtask == 'notebooks'
         run: |
           # Run notebooks only if numba is installed
-          if python -c 'import numba' 2> /dev/null ; then
-            jupyter nbconvert --to notebook --execute notebooks/*ipynb
-          fi
+          echo el barto
+          # if python -c 'import numba' 2> /dev/null ; then
+          #   jupyter nbconvert --to notebook --execute notebooks/*ipynb
+          # fi

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -85,13 +85,13 @@ jobs:
         shell: bash -l {0}
     strategy:
       # To "stress test" in CI, set `fail-fast` to `false` and perhaps add more items to `matrix.slowtask`
-      fail-fast: false
+      fail-fast: true
       # The build matrix is [os]x[slowtask] and then randomly chooses [pyver] and [sourcetype].
       # This should ensure we'll have full code coverage (i.e., no chance of getting unlucky),
       # since we need to run all slow tests on Windows and non-Windoes OSes.
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest", "ubuntu-latest", "macos-latest", "windows-latest", "ubuntu-latest", "macos-latest", "windows-latest"]
-        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks", "pytest_normal", "pytest_bizarro", "notebooks"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        slowtask: ["pytest_normal", "pytest_bizarro", "notebooks"]
     env:
       # Wheels on OS X come with an OpenMP that conflicts with OpenMP from conda-forge.
       # Setting this is a workaround.
@@ -316,10 +316,9 @@ jobs:
       - name: python-suitesparse-graphblas tests
         run: |
           # Don't use our conftest.py ; allow `test_print_jit_config` to fail if it doesn't exist
-          echo el barto
-          # (cd ..
-          #  pytest --pyargs suitesparse_graphblas -s -k test_print_jit_config || true
-          #  pytest -v --pyargs suitesparse_graphblas)
+          (cd ..
+           pytest --pyargs suitesparse_graphblas -s -k test_print_jit_config || true
+           pytest -v --pyargs suitesparse_graphblas)
       - name: Unit tests
         run: |
           A=${{ needs.rngs.outputs.mapnumpy == 'A' || '' }} ; B=${{ needs.rngs.outputs.mapnumpy == 'B' || '' }}
@@ -348,9 +347,8 @@ jobs:
             if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $suitesparse" ; elif [[ $windows ]] ; then echo " $vanilla"     ; fi ; fi)
           echo ${args}
           set -x  # echo on
-          echo el barto
-          # coverage run -m pytest --color=yes --randomly -v ${args} \
-          #   ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
+          coverage run -m pytest --color=yes --randomly -v ${args} \
+            ${{ matrix.slowtask == 'pytest_normal' && '--runslow' || '' }}
       - name: Unit tests (bizarro scalars)
         run: |
           # Run tests again with Scalars being C scalars by default
@@ -385,9 +383,8 @@ jobs:
             if [[ $H && $bizarro ]] ; then if [[ $macos  ]] ; then echo " $vanilla"     ; elif [[ $windows ]] ; then echo " $suitesparse" ; fi ; fi)
           echo ${args}
           set -x  # echo on
-          echo el barto
-          # coverage run -a -m pytest --color=yes --randomly -v ${args} \
-          #   ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
+          coverage run -a -m pytest --color=yes --randomly -v ${args} \
+            ${{ matrix.slowtask == 'pytest_bizarro' && '--runslow' || '' }}
           git checkout .  # Undo changes to scalar default
       - name: Miscellaneous tests
         if: matrix.slowtask == 'pytest_normal'
@@ -416,10 +413,9 @@ jobs:
         if: matrix.slowtask == 'notebooks' && matrix.os == 'windows-latest'
         run: |
           # We use 'notebooks' slow task b/c it should have numba installed
-          echo el barto
-          # coverage run -a -m pytest --color=yes --runslow --no-mapnumpy -p no:randomly -v -k 'test_commutes or test_bool_doesnt_get_too_large or test_npbinary or test_npmonoid or test_npsemiring'
-          # coverage run -a -m pytest --color=yes --runslow --mapnumpy -p no:randomly -k 'test_bool_doesnt_get_too_large or test_npunary or test_binaryop_monoid_numpy'
-          # coverage run -a -m pytest --color=yes -x --no-mapnumpy --runslow -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
+          coverage run -a -m pytest --color=yes --runslow --no-mapnumpy -p no:randomly -v -k 'test_commutes or test_bool_doesnt_get_too_large or test_npbinary or test_npmonoid or test_npsemiring'
+          coverage run -a -m pytest --color=yes --runslow --mapnumpy -p no:randomly -k 'test_bool_doesnt_get_too_large or test_npunary or test_binaryop_monoid_numpy'
+          coverage run -a -m pytest --color=yes -x --no-mapnumpy --runslow -k test_binaryop_attributes_numpy graphblas/tests/test_op.py
       - name: Auto-generated code check
         if: matrix.slowtask == 'pytest_bizarro'
         run: |
@@ -432,12 +428,11 @@ jobs:
           coverage xml
           coverage report --show-missing
       - name: codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
       - name: Notebooks Execution check
         if: matrix.slowtask == 'notebooks'
         run: |
           # Run notebooks only if numba is installed
-          echo el barto
-          # if python -c 'import numba' 2> /dev/null ; then
-          #   jupyter nbconvert --to notebook --execute notebooks/*ipynb
-          # fi
+          if python -c 'import numba' 2> /dev/null ; then
+            jupyter nbconvert --to notebook --execute notebooks/*ipynb
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: name-tests-test
         args: ["--pytest-test-first"]
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.15
+    rev: v0.16
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
@@ -61,25 +61,25 @@ repos:
       - id: auto-walrus
         args: [--line-length, "100"]
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix-only, --show-fixes]
   # Let's keep `flake8` even though `ruff` does much of the same.
   # `flake8-bugbear` and `flake8-simplify` have caught things missed by `ruff`.
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies: &flake8_dependencies
         # These versions need updated manually
-        - flake8==6.1.0
-        - flake8-bugbear==23.12.2
+        - flake8==7.0.0
+        - flake8-bugbear==24.1.17
         - flake8-simplify==0.21.0
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
@@ -94,7 +94,7 @@ repos:
         additional_dependencies: [tomli]
         files: ^(graphblas|docs)/
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: v0.2.1
     hooks:
       - id: ruff
   - repo: https://github.com/sphinx-contrib/sphinx-lint

--- a/graphblas/agg/__init__.py
+++ b/graphblas/agg/__init__.py
@@ -73,6 +73,7 @@ Custom recipes (specific to SuiteSparse:GraphBLAS):
 #   - bxnor monoid: even bits
 #   - bnor monoid: odd bits
 """
+
 # All items are dynamically added by classes in core/operator/agg.py
 # This module acts as a container of Aggregator instances
 _deprecated = {}

--- a/graphblas/binary/numpy.py
+++ b/graphblas/binary/numpy.py
@@ -5,6 +5,7 @@ See list of numpy ufuncs supported by numpy here:
 https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
+
 import numpy as _np
 
 from .. import _STANDARD_OPERATOR_NAMES

--- a/graphblas/core/automethods.py
+++ b/graphblas/core/automethods.py
@@ -7,6 +7,7 @@ To automatically create the functions, run:
 $ python -m graphblas.core.automethods
 
 """
+
 from .. import config
 
 

--- a/graphblas/core/dtypes.py
+++ b/graphblas/core/dtypes.py
@@ -375,8 +375,7 @@ def lookup_dtype(key, value=None):
 
 
 def unify(type1, type2, *, is_left_scalar=False, is_right_scalar=False):
-    """
-    Returns a type that can hold both type1 and type2.
+    """Returns a type that can hold both type1 and type2.
 
     For example:
     unify(INT32, INT64) -> INT64

--- a/graphblas/core/expr.py
+++ b/graphblas/core/expr.py
@@ -147,13 +147,13 @@ class IndexerResolver:
         return self.indices[0]._py_index()
 
     def parse_indices(self, indices, shape):
-        """
-        Returns
+        """Returns
         -------
             [(rows, rowsize), (cols, colsize)] for Matrix
             [(idx, idx_size)] for Vector
 
         Within each tuple, if the index is of type int, the size will be None
+
         """
         if len(shape) == 1:
             if type(indices) is tuple:
@@ -312,8 +312,8 @@ class AmbiguousAssignOrExtract:
         Updater(self.parent, opts=opts)._setitem(self.resolved_indexes, expr, is_submask=False)
 
     def new(self, dtype=None, *, mask=None, input_mask=None, name=None, **opts):
-        """
-        Force extraction of the indexes into a new object
+        """Force extraction of the indexes into a new object.
+
         dtype and mask are the only controllable parameters.
         """
         if input_mask is not None:

--- a/graphblas/core/matrix.py
+++ b/graphblas/core/matrix.py
@@ -177,6 +177,7 @@ class Matrix(BaseType):
         Number of columns.
     name : str, optional
         Name to give the Matrix. This will be displayed in the ``__repr__``.
+
     """
 
     __slots__ = "_nrows", "_ncols", "_parent", "ss"
@@ -296,6 +297,7 @@ class Matrix(BaseType):
         Examples
         --------
             >>> del M[1, 5]
+
         """
         del Updater(self, opts=opts)[keys]
 
@@ -310,6 +312,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             subM = M[[1, 3, 5], :].new()
+
         """
         resolved_indexes = IndexerResolver(self, keys)
         shape = resolved_indexes.shape
@@ -331,6 +334,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             M[0, 0:3] = 17
+
         """
         Updater(self, opts=opts)[keys] = expr
 
@@ -342,6 +346,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             (10, 15) in M
+
         """
         extractor = self[index]
         if not extractor._is_scalar:
@@ -381,6 +386,7 @@ class Matrix(BaseType):
         See Also
         --------
         :meth:`isclose` : For equality check of floating point dtypes
+
         """
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within="isequal", argname="other"
@@ -427,6 +433,7 @@ class Matrix(BaseType):
         -------
         bool
             Whether all values of the Matrix are close to the values in ``other``.
+
         """
         other = self._expect_type(
             other, (Matrix, TransposedMatrix), within="isclose", argname="other"
@@ -544,6 +551,7 @@ class Matrix(BaseType):
         np.ndarray[dtype=uint64] : Rows
         np.ndarray[dtype=uint64] : Columns
         np.ndarray : Values
+
         """
         if sort and backend == "suitesparse":
             self.wait()  # sort in SS
@@ -610,6 +618,7 @@ class Matrix(BaseType):
         -------
         np.ndarray[dtype=uint64] : Edgelist
         np.ndarray : Values
+
         """
         rows, columns, values = self.to_coo(dtype, values=values, sort=sort)
         return (np.column_stack([rows, columns]), values)
@@ -690,6 +699,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         if dtype is not None or mask is not None or clear:
             if dtype is None:
@@ -721,6 +731,7 @@ class Matrix(BaseType):
         Returns
         -------
         :class:`~graphblas.Vector`
+
         """
         if backend == "suitesparse":
             from ..ss._core import diag
@@ -764,6 +775,7 @@ class Matrix(BaseType):
         Use wait to force completion of the Matrix.
 
         Has no effect in `blocking mode <../user_guide/init.html#graphblas-modes>`__.
+
         """
         how = how.lower()
         if how == "materialize":
@@ -790,6 +802,7 @@ class Matrix(BaseType):
         Returns
         -------
         Python scalar
+
         """
         expr = self[row, col]
         if expr._is_scalar:
@@ -847,6 +860,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         rows = ints_to_numpy_buffer(rows, np.uint64, name="row indices")
         columns = ints_to_numpy_buffer(columns, np.uint64, name="column indices")
@@ -926,6 +940,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         edgelist_values = None
         if isinstance(edgelist, np.ndarray):
@@ -1095,6 +1110,7 @@ class Matrix(BaseType):
         to_csr
         Matrix.ss.import_csr
         io.from_scipy_sparse
+
         """
         return cls._from_csx(_CSR_FORMAT, indptr, col_indices, values, dtype, ncols, nrows, name)
 
@@ -1142,6 +1158,7 @@ class Matrix(BaseType):
         to_csc
         Matrix.ss.import_csc
         io.from_scipy_sparse
+
         """
         return cls._from_csx(_CSC_FORMAT, indptr, row_indices, values, dtype, nrows, ncols, name)
 
@@ -1202,6 +1219,7 @@ class Matrix(BaseType):
         to_dcsr
         Matrix.ss.import_hypercsr
         io.from_scipy_sparse
+
         """
         if backend == "suitesparse":
             return cls.ss.import_hypercsr(
@@ -1286,6 +1304,7 @@ class Matrix(BaseType):
         to_dcsc
         Matrix.ss.import_hypercsc
         io.from_scipy_sparse
+
         """
         if backend == "suitesparse":
             return cls.ss.import_hypercsc(
@@ -1347,6 +1366,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         if type(value) is not Scalar:
             try:
@@ -1400,6 +1420,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         values, dtype = values_to_numpy_buffer(values, dtype, subarray_after=2)
         if values.ndim == 0:
@@ -1459,6 +1480,7 @@ class Matrix(BaseType):
         Returns
         -------
         np.ndarray
+
         """
         max_nvals = self._nrows * self._ncols
         if fill_value is None or self._nvals == max_nvals:
@@ -1534,6 +1556,7 @@ class Matrix(BaseType):
         Returns
         -------
         Matrix
+
         """
         order = get_order(order)
         if isinstance(nested_dicts, Sequence):
@@ -1643,6 +1666,7 @@ class Matrix(BaseType):
         from_csr
         Matrix.ss.export
         io.to_scipy_sparse
+
         """
         if backend == "suitesparse":
             info = self.ss.export("csr", sort=sort)
@@ -1674,6 +1698,7 @@ class Matrix(BaseType):
         from_csc
         Matrix.ss.export
         io.to_scipy_sparse
+
         """
         if backend == "suitesparse":
             info = self.ss.export("csc", sort=sort)
@@ -1708,6 +1733,7 @@ class Matrix(BaseType):
         from_dcsc
         Matrix.ss.export
         io.to_scipy_sparse
+
         """
         if backend == "suitesparse":
             info = self.ss.export("hypercsr", sort=sort)
@@ -1750,6 +1776,7 @@ class Matrix(BaseType):
         from_dcsc
         Matrix.ss.export
         io.to_scipy_sparse
+
         """
         if backend == "suitesparse":
             info = self.ss.export("hypercsc", sort=sort)
@@ -1787,6 +1814,7 @@ class Matrix(BaseType):
         Returns
         -------
         dict
+
         """
         order = get_order(order)
         if order == "rowwise":
@@ -1856,6 +1884,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << monoid.max(A | B)
+
         """
         return self._ewise_add(other, op)
 
@@ -1946,6 +1975,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << binary.gt(A & B)
+
         """
         return self._ewise_mult(other, op)
 
@@ -2040,6 +2070,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << binary.div(A | B, left_default=1, right_default=1)
+
         """
         return self._ewise_union(other, op, left_default, right_default)
 
@@ -2193,6 +2224,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << semiring.min_plus(A @ v)
+
         """
         return self._mxv(other, op)
 
@@ -2253,6 +2285,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << semiring.min_plus(A @ B)
+
         """
         return self._mxm(other, op)
 
@@ -2317,6 +2350,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             C << A.kronecker(B, op=binary.times)
+
         """
         method_name = "kronecker"
         other = self._expect_type(
@@ -2373,6 +2407,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << op.abs(A)
+
         """
         method_name = "apply"
         extra_message = (
@@ -2521,6 +2556,7 @@ class Matrix(BaseType):
 
             # Functional syntax
             C << select.value(A >= 1)
+
         """
         method_name = "select"
         if isinstance(op, str):
@@ -2615,6 +2651,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             w << A.reduce_rowwise(monoid.plus)
+
         """
         method_name = "reduce_rowwise"
         op = get_typed_op(op, self.dtype, kind="binary|aggregator")
@@ -2652,6 +2689,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             w << A.reduce_columnwise(monoid.plus)
+
         """
         method_name = "reduce_columnwise"
         op = get_typed_op(op, self.dtype, kind="binary|aggregator")
@@ -2670,8 +2708,7 @@ class Matrix(BaseType):
         )
 
     def reduce_scalar(self, op=monoid.plus, *, allow_empty=True):
-        """
-        Reduce all values in the Matrix into a single value using ``op``.
+        """Reduce all values in the Matrix into a single value using ``op``.
 
         See the `Reduce <../user_guide/operations.html#reduce>`__
         section in the User Guide for more details.
@@ -2693,6 +2730,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             total << A.reduce_scalar(monoid.plus)
+
         """
         method_name = "reduce_scalar"
         op = get_typed_op(op, self.dtype, kind="binary|aggregator")
@@ -2753,6 +2791,7 @@ class Matrix(BaseType):
         .. code-block:: python
 
             C = A.reposition(1, 2).new()
+
         """
         if nrows is None:
             nrows = self._nrows
@@ -2834,6 +2873,7 @@ class Matrix(BaseType):
             C = A.dup()
             for i in range(1, 4):
                 C << A @ C
+
         """
         method_name = "power"
         if self._nrows != self._ncols:
@@ -2878,6 +2918,7 @@ class Matrix(BaseType):
             If it is Matrix Mask, then only the diagonal is used as the mask.
         accum : Monoid or BinaryOp, optional
             Operator to use to combine existing diagonal values and new values.
+
         """
         if (K := maybe_integral(k)) is None:
             raise TypeError(f"k must be an integer; got bad type: {type(k)}")

--- a/graphblas/core/operator/base.py
+++ b/graphblas/core/operator/base.py
@@ -405,7 +405,8 @@ class OpBase:
 
     @classmethod
     def _initialize(cls, include_in_ops=True):
-        """
+        """Initialize operators for this operator type.
+
         include_in_ops determines whether the operators are included in the
         ``gb.ops`` namespace in addition to the defined module.
         """

--- a/graphblas/core/operator/binary.py
+++ b/graphblas/core/operator/binary.py
@@ -663,6 +663,7 @@ class BinaryOp(OpBase):
         Returns
         -------
         BinaryOp or ParameterizedBinaryOp
+
         """
         cls._check_supports_udf("register_anonymous")
         if parameterized:
@@ -725,6 +726,7 @@ class BinaryOp(OpBase):
         >>>         return x == y or abs(x - y) <= max(rel_tol * max(abs(x), abs(y)), abs_tol)
         >>>     return inner
         >>> gb.binary.register_new("user_isclose", user_isclose, parameterized=True)
+
         """
         cls._check_supports_udf("register_new")
         module, funcname = cls._remove_nesting(name)

--- a/graphblas/core/operator/indexunary.py
+++ b/graphblas/core/operator/indexunary.py
@@ -285,6 +285,7 @@ class IndexUnaryOp(OpBase):
         Returns
         -------
         return IndexUnaryOp or ParameterizedIndexUnaryOp
+
         """
         cls._check_supports_udf("register_anonymous")
         if parameterized:
@@ -340,6 +341,7 @@ class IndexUnaryOp(OpBase):
         >>> gb.indexunary.register_new("row_mod", lambda x, i, j, thunk: i % max(thunk, 2))
         >>> dir(gb.indexunary)
         [..., 'row_mod', ...]
+
         """
         cls._check_supports_udf("register_new")
         module, funcname = cls._remove_nesting(name)

--- a/graphblas/core/operator/monoid.py
+++ b/graphblas/core/operator/monoid.py
@@ -270,6 +270,7 @@ class Monoid(OpBase):
         Returns
         -------
         Monoid or ParameterizedMonoid
+
         """
         if type(binaryop) is ParameterizedBinaryOp:
             return ParameterizedMonoid(
@@ -309,6 +310,7 @@ class Monoid(OpBase):
         >>> gb.core.operator.Monoid.register_new("max_zero", gb.binary.max_zero, 0)
         >>> dir(gb.monoid)
         [..., 'max_zero', ...]
+
         """
         module, funcname = cls._remove_nesting(name)
         if lazy:

--- a/graphblas/core/operator/select.py
+++ b/graphblas/core/operator/select.py
@@ -208,6 +208,7 @@ class SelectOp(OpBase):
         Returns
         -------
         SelectOp or ParameterizedSelectOp
+
         """
         cls._check_supports_udf("register_anonymous")
         if parameterized:
@@ -264,6 +265,7 @@ class SelectOp(OpBase):
         >>> gb.select.register_new("upper_left_triangle", lambda x, i, j, thunk: i + j <= thunk)
         >>> dir(gb.select)
         [..., 'upper_left_triangle', ...]
+
         """
         cls._check_supports_udf("register_new")
         iop = IndexUnaryOp.register_new(

--- a/graphblas/core/operator/semiring.py
+++ b/graphblas/core/operator/semiring.py
@@ -287,6 +287,7 @@ class Semiring(OpBase):
         Returns
         -------
         Semiring or ParameterizedSemiring
+
         """
         if type(monoid) is ParameterizedMonoid or type(binaryop) is ParameterizedBinaryOp:
             return ParameterizedSemiring(name, monoid, binaryop, anonymous=True)
@@ -318,6 +319,7 @@ class Semiring(OpBase):
         >>> gb.core.operator.Semiring.register_new("max_max", gb.monoid.max, gb.binary.max)
         >>> dir(gb.semiring)
         [..., 'max_max', ...]
+
         """
         module, funcname = cls._remove_nesting(name)
         if lazy:

--- a/graphblas/core/operator/unary.py
+++ b/graphblas/core/operator/unary.py
@@ -304,6 +304,7 @@ class UnaryOp(OpBase):
         Returns
         -------
         UnaryOp or ParameterizedUnaryOp
+
         """
         cls._check_supports_udf("register_anonymous")
         if parameterized:
@@ -349,6 +350,7 @@ class UnaryOp(OpBase):
         >>> gb.core.operator.UnaryOp.register_new("plus_one", lambda x: x + 1)
         >>> dir(gb.unary)
         [..., 'plus_one', ...]
+
         """
         cls._check_supports_udf("register_new")
         module, funcname = cls._remove_nesting(name)

--- a/graphblas/core/operator/utils.py
+++ b/graphblas/core/operator/utils.py
@@ -170,6 +170,7 @@ def get_semiring(monoid, binaryop, name=None):
     semiring.register_anonymous
     semiring.register_new
     semiring.from_string
+
     """
     monoid, opclass = find_opclass(monoid)
     switched = False

--- a/graphblas/core/scalar.py
+++ b/graphblas/core/scalar.py
@@ -53,6 +53,7 @@ class Scalar(BaseType):
         with a proper GrB_Scalar object.
     name : str, optional
         Name to give the Scalar. This will be displayed in the ``__repr__``.
+
     """
 
     __slots__ = "_empty", "_is_cscalar"
@@ -196,6 +197,7 @@ class Scalar(BaseType):
         See Also
         --------
         :meth:`isclose` : For equality check of floating point dtypes
+
         """
         if type(other) is not Scalar:
             if other is None:
@@ -245,6 +247,7 @@ class Scalar(BaseType):
         Returns
         -------
         bool
+
         """
         if type(other) is not Scalar:
             if other is None:
@@ -428,6 +431,7 @@ class Scalar(BaseType):
         Returns
         -------
         Scalar
+
         """
         if is_cscalar is None:
             is_cscalar = self._is_cscalar
@@ -473,6 +477,7 @@ class Scalar(BaseType):
         Use wait to force completion of the Scalar.
 
         Has no effect in `blocking mode <../user_guide/init.html#graphblas-modes>`__.
+
         """
         how = how.lower()
         if how == "materialize":
@@ -496,6 +501,7 @@ class Scalar(BaseType):
         Returns
         -------
         Python scalar
+
         """
         return default if self._is_empty else self.value
 
@@ -519,6 +525,7 @@ class Scalar(BaseType):
         Returns
         -------
         Scalar
+
         """
         typ = output_type(value)
         if dtype is None:
@@ -628,6 +635,7 @@ class Scalar(BaseType):
 
             # Functional syntax
             c << monoid.max(a | b)
+
         """
         return self._ewise_add(other, op)
 
@@ -698,6 +706,7 @@ class Scalar(BaseType):
 
             # Functional syntax
             c << binary.gt(a & b)
+
         """
         return self._ewise_mult(other, op)
 
@@ -772,6 +781,7 @@ class Scalar(BaseType):
 
             # Functional syntax
             c << binary.div(a | b, left_default=1, right_default=1)
+
         """
         return self._ewise_union(other, op, left_default, right_default)
 
@@ -917,6 +927,7 @@ class Scalar(BaseType):
 
             # Functional syntax
             b << op.abs(a)
+
         """
         expr = self._as_vector().apply(op, right, left=left)
         return ScalarExpression(

--- a/graphblas/core/ss/binary.py
+++ b/graphblas/core/ss/binary.py
@@ -71,6 +71,7 @@ def register_new(name, jit_c_definition, left_type, right_type, ret_type):
     gb.binary.register_new
     gb.binary.register_anonymous
     gb.unary.ss.register_new
+
     """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(

--- a/graphblas/core/ss/descriptor.py
+++ b/graphblas/core/ss/descriptor.py
@@ -157,6 +157,7 @@ def get_descriptor(**opts):
     Returns
     -------
     Descriptor or None
+
     """
     if not opts or all(val is False or val is None for val in opts.values()):
         return

--- a/graphblas/core/ss/indexunary.py
+++ b/graphblas/core/ss/indexunary.py
@@ -70,6 +70,7 @@ def register_new(name, jit_c_definition, input_type, thunk_type, ret_type):
     gb.indexunary.register_new
     gb.indexunary.register_anonymous
     gb.select.ss.register_new
+
     """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(

--- a/graphblas/core/ss/matrix.py
+++ b/graphblas/core/ss/matrix.py
@@ -250,8 +250,7 @@ class ss:
         return "rowwise"
 
     def build_diag(self, vector, k=0, **opts):
-        """
-        GxB_Matrix_diag.
+        """GxB_Matrix_diag.
 
         Construct a diagonal Matrix from the given vector.
         Existing entries in the Matrix are discarded.
@@ -279,8 +278,7 @@ class ss:
         )
 
     def split(self, chunks, *, name=None, **opts):
-        """
-        GxB_Matrix_split.
+        """GxB_Matrix_split.
 
         Split a Matrix into a 2D array of sub-matrices according to ``chunks``.
 
@@ -302,6 +300,7 @@ class ss:
         --------
         Matrix.ss.concat
         graphblas.ss.concat
+
         """
         from ..matrix import Matrix
 
@@ -361,8 +360,7 @@ class ss:
         )
 
     def concat(self, tiles, **opts):
-        """
-        GxB_Matrix_concat.
+        """GxB_Matrix_concat.
 
         Concatenate a 2D list of Matrix objects into the current Matrix.
         Any existing values in the current Matrix will be discarded.
@@ -376,13 +374,13 @@ class ss:
         --------
         Matrix.ss.split
         graphblas.ss.concat
+
         """
         tiles, m, n, is_matrix = _concat_mn(tiles, is_matrix=True)
         self._concat(tiles, m, n, opts)
 
     def build_scalar(self, rows, columns, value):
-        """
-        GxB_Matrix_build_Scalar.
+        """GxB_Matrix_build_Scalar.
 
         Like ``build``, but uses a scalar for all the values.
 
@@ -390,6 +388,7 @@ class ss:
         --------
         Matrix.build
         Matrix.from_coo
+
         """
         rows = ints_to_numpy_buffer(rows, np.uint64, name="row indices")
         columns = ints_to_numpy_buffer(columns, np.uint64, name="column indices")
@@ -536,8 +535,7 @@ class ss:
             lib.GxB_Iterator_free(it_ptr)
 
     def export(self, format=None, *, sort=False, give_ownership=False, raw=False, **opts):
-        """
-        GxB_Matrix_export_xxx.
+        """GxB_Matrix_export_xxx.
 
         Parameters
         ----------
@@ -718,6 +716,7 @@ class ss:
 
         >>> pieces = A.ss.export()
         >>> A2 = Matrix.ss.import_any(**pieces)
+
         """
         return self._export(
             format,
@@ -729,8 +728,7 @@ class ss:
         )
 
     def unpack(self, format=None, *, sort=False, raw=False, **opts):
-        """
-        GxB_Matrix_unpack_xxx.
+        """GxB_Matrix_unpack_xxx.
 
         ``unpack`` is like ``export``, except that the Matrix remains valid but empty.
         ``pack_*`` methods are the opposite of ``unpack``.
@@ -1179,8 +1177,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_CSR.
+        """GxB_Matrix_import_CSR.
 
         Create a new Matrix from standard CSR format.
 
@@ -1220,6 +1217,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_csr(
             nrows=nrows,
@@ -1256,8 +1254,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_CSR.
+        """GxB_Matrix_pack_CSR.
 
         ``pack_csr`` is like ``import_csr`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("csr")``
@@ -1369,8 +1366,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_CSC.
+        """GxB_Matrix_import_CSC.
 
         Create a new Matrix from standard CSC format.
 
@@ -1410,6 +1406,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_csc(
             nrows=nrows,
@@ -1446,8 +1443,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_CSC.
+        """GxB_Matrix_pack_CSC.
 
         ``pack_csc`` is like ``import_csc`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("csc")``
@@ -1561,8 +1557,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_HyperCSR.
+        """GxB_Matrix_import_HyperCSR.
 
         Create a new Matrix from standard HyperCSR format.
 
@@ -1606,6 +1601,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_hypercsr(
             nrows=nrows,
@@ -1646,8 +1642,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_HyperCSR.
+        """GxB_Matrix_pack_HyperCSR.
 
         ``pack_hypercsr`` is like ``import_hypercsr`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("hypercsr")``
@@ -1785,8 +1780,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_HyperCSC.
+        """GxB_Matrix_import_HyperCSC.
 
         Create a new Matrix from standard HyperCSC format.
 
@@ -1830,6 +1824,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_hypercsc(
             nrows=nrows,
@@ -1870,8 +1865,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_HyperCSC.
+        """GxB_Matrix_pack_HyperCSC.
 
         ``pack_hypercsc`` is like ``import_hypercsc`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("hypercsc")``
@@ -2006,8 +2000,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_BitmapR.
+        """GxB_Matrix_import_BitmapR.
 
         Create a new Matrix from values and bitmap (as mask) arrays.
 
@@ -2053,6 +2046,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_bitmapr(
             bitmap=bitmap,
@@ -2087,8 +2081,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_BitmapR.
+        """GxB_Matrix_pack_BitmapR.
 
         ``pack_bitmapr`` is like ``import_bitmapr`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("bitmapr")``
@@ -2199,8 +2192,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_BitmapC.
+        """GxB_Matrix_import_BitmapC.
 
         Create a new Matrix from values and bitmap (as mask) arrays.
 
@@ -2246,6 +2238,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_bitmapc(
             bitmap=bitmap,
@@ -2280,8 +2273,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_BitmapC.
+        """GxB_Matrix_pack_BitmapC.
 
         ``pack_bitmapc`` is like ``import_bitmapc`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("bitmapc")``
@@ -2390,8 +2382,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_FullR.
+        """GxB_Matrix_import_FullR.
 
         Create a new Matrix from values.
 
@@ -2432,6 +2423,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_fullr(
             values=values,
@@ -2462,8 +2454,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_FullR.
+        """GxB_Matrix_pack_FullR.
 
         ``pack_fullr`` is like ``import_fullr`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("fullr")``
@@ -2549,8 +2540,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_FullC.
+        """GxB_Matrix_import_FullC.
 
         Create a new Matrix from values.
 
@@ -2591,6 +2581,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_fullc(
             values=values,
@@ -2621,8 +2612,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_FullC.
+        """GxB_Matrix_pack_FullC.
 
         ``pack_fullc`` is like ``import_fullc`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("fullc")``
@@ -2711,8 +2701,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GrB_Matrix_build_XXX and GxB_Matrix_build_Scalar.
+        """GrB_Matrix_build_XXX and GxB_Matrix_build_Scalar.
 
         Create a new Matrix from indices and values in coordinate format.
 
@@ -2746,6 +2735,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_coo(
             rows=rows,
@@ -2784,8 +2774,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GrB_Matrix_build_XXX and GxB_Matrix_build_Scalar.
+        """GrB_Matrix_build_XXX and GxB_Matrix_build_Scalar.
 
         ``pack_coo`` is like ``import_coo`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("coo")``
@@ -2897,8 +2886,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_CSR.
+        """GxB_Matrix_import_CSR.
 
         Create a new Matrix from indices and values in coordinate format.
         Rows must be sorted.
@@ -2942,6 +2930,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_coor(
             rows=rows,
@@ -2980,8 +2969,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_CSR.
+        """GxB_Matrix_pack_CSR.
 
         ``pack_coor`` is like ``import_coor`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("coor")``
@@ -3066,8 +3054,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_import_CSC.
+        """GxB_Matrix_import_CSC.
 
         Create a new Matrix from indices and values in coordinate format.
         Rows must be sorted.
@@ -3111,6 +3098,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         return cls._import_cooc(
             rows=rows,
@@ -3149,8 +3137,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_CSC.
+        """GxB_Matrix_pack_CSC.
 
         ``pack_cooc`` is like ``import_cooc`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack("cooc")``
@@ -3251,8 +3238,7 @@ class ss:
         nvals=None,  # optional
         **opts,
     ):
-        """
-        GxB_Matrix_import_xxx.
+        """GxB_Matrix_import_xxx.
 
         Dispatch to appropriate import method inferred from inputs.
         See the other import functions and ``Matrix.ss.export`` for details.
@@ -3280,6 +3266,7 @@ class ss:
 
         >>> pieces = A.ss.export()
         >>> A2 = Matrix.ss.import_any(**pieces)
+
         """
         return cls._import_any(
             values=values,
@@ -3349,8 +3336,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Matrix_pack_xxx.
+        """GxB_Matrix_pack_xxx.
 
         ``pack_any`` is like ``import_any`` except it "packs" data into an
         existing Matrix.  This is the opposite of ``unpack()``
@@ -3707,6 +3693,7 @@ class ss:
         Returns
         -------
         Matrix
+
         """
         order = get_order(order)
         parent = self._parent
@@ -3735,6 +3722,7 @@ class ss:
         See Also
         --------
         Vector.ss.reshape : copy a Vector to a Matrix.
+
         """
         rv = self.reshape(-1, 1, order=order, name=name, **opts)
         return rv._as_vector()
@@ -3771,6 +3759,7 @@ class ss:
         --------
         Matrix.ss.flatten : flatten a Matrix into a Vector.
         Vector.ss.reshape : copy a Vector to a Matrix.
+
         """
         from ..matrix import Matrix
 
@@ -3825,6 +3814,7 @@ class ss:
             The number of elements to choose from each row
 
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+
         """
         # TODO: largest, smallest, random_weighted
         order = get_order(order)
@@ -4021,6 +4011,7 @@ class ss:
         See Also
         --------
         Matrix.ss.compactify
+
         """
         from ..matrix import Matrix
 
@@ -4082,6 +4073,7 @@ class ss:
         This method is intended to support all serialization options from SuiteSparse:GraphBLAS.
 
         *Warning*: Behavior of serializing UDTs is experimental and may change in a future release.
+
         """
         desc = get_descriptor(compression=compression, compression_level=level, **opts)
         blob_handle = ffi_new("void**")
@@ -4121,6 +4113,7 @@ class ss:
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
+
         """
         if isinstance(data, np.ndarray):
             data = ints_to_numpy_buffer(data, np.uint8)

--- a/graphblas/core/ss/select.py
+++ b/graphblas/core/ss/select.py
@@ -66,6 +66,7 @@ def register_new(name, jit_c_definition, input_type, thunk_type):
     gb.select.register_new
     gb.select.register_anonymous
     gb.indexunary.ss.register_new
+
     """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(

--- a/graphblas/core/ss/unary.py
+++ b/graphblas/core/ss/unary.py
@@ -63,6 +63,7 @@ def register_new(name, jit_c_definition, input_type, ret_type):
     gb.unary.register_new
     gb.unary.register_anonymous
     gb.binary.ss.register_new
+
     """
     if backend != "suitesparse":  # pragma: no cover (safety)
         raise RuntimeError(

--- a/graphblas/core/ss/vector.py
+++ b/graphblas/core/ss/vector.py
@@ -145,8 +145,7 @@ class ss:
         return format
 
     def build_diag(self, matrix, k=0, **opts):
-        """
-        GxB_Vector_diag.
+        """GxB_Vector_diag.
 
         Extract a diagonal from a Matrix or TransposedMatrix into a Vector.
         Existing entries in the Vector are discarded.
@@ -183,8 +182,7 @@ class ss:
         )
 
     def split(self, chunks, *, name=None, **opts):
-        """
-        GxB_Matrix_split.
+        """GxB_Matrix_split.
 
         Split a Vector into a 1D array of sub-vectors according to ``chunks``.
 
@@ -202,6 +200,7 @@ class ss:
         --------
         Vector.ss.concat
         graphblas.ss.concat
+
         """
         from ..vector import Vector
 
@@ -249,8 +248,7 @@ class ss:
         )
 
     def concat(self, tiles, **opts):
-        """
-        GxB_Matrix_concat.
+        """GxB_Matrix_concat.
 
         Concatenate a 1D list of Vector objects into the current Vector.
         Any existing values in the current Vector will be discarded.
@@ -262,13 +260,13 @@ class ss:
         --------
         Vector.ss.split
         graphblas.ss.concat
+
         """
         tiles, m, n, is_matrix = _concat_mn(tiles, is_matrix=False)
         self._concat(tiles, m, opts)
 
     def build_scalar(self, indices, value):
-        """
-        GxB_Vector_build_Scalar.
+        """GxB_Vector_build_Scalar.
 
         Like ``build``, but uses a scalar for all the values.
 
@@ -276,6 +274,7 @@ class ss:
         --------
         Vector.build
         Vector.from_coo
+
         """
         indices = ints_to_numpy_buffer(indices, np.uint64, name="indices")
         scalar = _as_scalar(value, self._parent.dtype, is_cscalar=False)  # pragma: is_grbscalar
@@ -410,8 +409,7 @@ class ss:
             lib.GxB_Iterator_free(it_ptr)
 
     def export(self, format=None, *, sort=False, give_ownership=False, raw=False, **opts):
-        """
-        GxB_Vextor_export_xxx.
+        """GxB_Vextor_export_xxx.
 
         Parameters
         ----------
@@ -468,6 +466,7 @@ class ss:
 
         >>> pieces = v.ss.export()
         >>> v2 = Vector.ss.import_any(**pieces)
+
         """
         return self._export(
             format=format,
@@ -479,8 +478,7 @@ class ss:
         )
 
     def unpack(self, format=None, *, sort=False, raw=False, **opts):
-        """
-        GxB_Vector_unpack_xxx.
+        """GxB_Vector_unpack_xxx.
 
         ``unpack`` is like ``export``, except that the Vector remains valid but empty.
         ``pack_*`` methods are the opposite of ``unpack``.
@@ -655,8 +653,7 @@ class ss:
         nvals=None,  # optional
         **opts,
     ):
-        """
-        GxB_Vector_import_xxx.
+        """GxB_Vector_import_xxx.
 
         Dispatch to appropriate import method inferred from inputs.
         See the other import functions and ``Vector.ss.export`` for details.
@@ -679,6 +676,7 @@ class ss:
 
         >>> pieces = v.ss.export()
         >>> v2 = Vector.ss.import_any(**pieces)
+
         """
         return cls._import_any(
             values=values,
@@ -722,8 +720,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_pack_xxx.
+        """GxB_Vector_pack_xxx.
 
         ``pack_any`` is like ``import_any`` except it "packs" data into an
         existing Vector.  This is the opposite of ``unpack()``
@@ -844,8 +841,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_import_CSC.
+        """GxB_Vector_import_CSC.
 
         Create a new Vector from sparse input.
 
@@ -886,6 +882,7 @@ class ss:
         Returns
         -------
         Vector
+
         """
         return cls._import_sparse(
             size=size,
@@ -920,8 +917,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_pack_CSC.
+        """GxB_Vector_pack_CSC.
 
         ``pack_sparse`` is like ``import_sparse`` except it "packs" data into an
         existing Vector.  This is the opposite of ``unpack("sparse")``
@@ -1029,8 +1025,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_import_Bitmap.
+        """GxB_Vector_import_Bitmap.
 
         Create a new Vector from values and bitmap (as mask) arrays.
 
@@ -1071,6 +1066,7 @@ class ss:
         Returns
         -------
         Vector
+
         """
         return cls._import_bitmap(
             bitmap=bitmap,
@@ -1103,8 +1099,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_pack_Bitmap.
+        """GxB_Vector_pack_Bitmap.
 
         ``pack_bitmap`` is like ``import_bitmap`` except it "packs" data into an
         existing Vector.  This is the opposite of ``unpack("bitmap")``
@@ -1214,8 +1209,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_import_Full.
+        """GxB_Vector_import_Full.
 
         Create a new Vector from values.
 
@@ -1252,6 +1246,7 @@ class ss:
         Returns
         -------
         Vector
+
         """
         return cls._import_full(
             values=values,
@@ -1280,8 +1275,7 @@ class ss:
         name=None,
         **opts,
     ):
-        """
-        GxB_Vector_pack_Full.
+        """GxB_Vector_pack_Full.
 
         ``pack_full`` is like ``import_full`` except it "packs" data into an
         existing Vector.  This is the opposite of ``unpack("full")``
@@ -1371,6 +1365,7 @@ class ss:
         Returns
         -------
         Scalar
+
         """
         return prefix_scan(self._parent, op, name=name, within="scan", **opts)
 
@@ -1401,6 +1396,7 @@ class ss:
         See Also
         --------
         Matrix.ss.flatten : flatten a Matrix into a Vector.
+
         """
         return self._parent._as_matrix().ss.reshape(nrows, ncols, order, name=name, **opts)
 
@@ -1420,6 +1416,7 @@ class ss:
             The number of elements to choose
 
         **THIS API IS EXPERIMENTAL AND MAY CHANGE**
+
         """
         how = how.lower()
         if k < 0:
@@ -1588,6 +1585,7 @@ class ss:
         See Also
         --------
         Vector.ss.compactify
+
         """
         from ..vector import Vector
 
@@ -1648,6 +1646,7 @@ class ss:
         This method is intended to support all serialization options from SuiteSparse:GraphBLAS.
 
         *Warning*: Behavior of serializing UDTs is experimental and may change in a future release.
+
         """
         desc = get_descriptor(compression=compression, compression_level=level, **opts)
         blob_handle = ffi_new("void**")
@@ -1687,6 +1686,7 @@ class ss:
         nthreads : int, optional
             The maximum number of threads to use when deserializing.
             None, 0 or negative nthreads means to use the default number of threads.
+
         """
         if isinstance(data, np.ndarray):
             data = ints_to_numpy_buffer(data, np.uint8)

--- a/graphblas/core/utils.py
+++ b/graphblas/core/utils.py
@@ -43,7 +43,7 @@ _output_types = {
     object: object,
     type: type,
 }
-_output_types.update((k, k) for k in np.cast)
+_output_types.update((k, k) for k in set(np.sctypeDict.values()))
 
 
 def output_type(val):
@@ -86,6 +86,7 @@ def values_to_numpy_buffer(
     -------
     np.ndarray
     dtype
+
     """
     if dtype is not None:
         dtype = lookup_dtype(dtype)
@@ -183,6 +184,7 @@ def normalize_chunks(chunks, shape):
     [(10,), (5, 15)]
     >>> normalize_chunks((5, (5, None)), shape)
     [(5, 5), (5, 15)]
+
     """
     if isinstance(chunks, (list, tuple)):
         pass

--- a/graphblas/core/vector.py
+++ b/graphblas/core/vector.py
@@ -149,6 +149,7 @@ class Vector(BaseType):
         Size of the Vector.
     name : str, optional
         Name to give the Vector. This will be displayed in the ``__repr__``.
+
     """
 
     __slots__ = "_size", "_parent", "ss"
@@ -265,6 +266,7 @@ class Vector(BaseType):
         Examples
         --------
             >>> del v[1:-1]
+
         """
         del Updater(self, opts=opts)[keys]
 
@@ -279,6 +281,7 @@ class Vector(BaseType):
         .. code-block:: python
 
             sub_v = v[[1, 3, 5]].new()
+
         """
         resolved_indexes = IndexerResolver(self, keys)
         shape = resolved_indexes.shape
@@ -298,6 +301,7 @@ class Vector(BaseType):
 
             # This makes a dense iso-value vector
             v[:] = 1
+
         """
         Updater(self, opts=opts)[keys] = expr
 
@@ -310,6 +314,7 @@ class Vector(BaseType):
 
             # Check if v[15] is non-empty
             15 in v
+
         """
         extractor = self[index]
         if not extractor._is_scalar:
@@ -349,6 +354,7 @@ class Vector(BaseType):
         See Also
         --------
         :meth:`isclose` : For equality check of floating point dtypes
+
         """
         other = self._expect_type(other, Vector, within="isequal", argname="other")
         if check_dtype and self.dtype != other.dtype:
@@ -391,6 +397,7 @@ class Vector(BaseType):
         Returns
         -------
         bool
+
         """
         other = self._expect_type(other, Vector, within="isclose", argname="other")
         if check_dtype and self.dtype != other.dtype:
@@ -479,6 +486,7 @@ class Vector(BaseType):
         -------
         np.ndarray[dtype=uint64] : Indices
         np.ndarray : Values
+
         """
         if sort and backend == "suitesparse":
             self.wait()  # sort in SS
@@ -578,6 +586,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         if dtype is not None or mask is not None or clear:
             if dtype is None:
@@ -608,6 +617,7 @@ class Vector(BaseType):
         Returns
         -------
         :class:`~graphblas.Matrix`
+
         """
         from .matrix import Matrix
 
@@ -632,6 +642,7 @@ class Vector(BaseType):
         Use wait to force completion of the Vector.
 
         Has no effect in `blocking mode <../user_guide/init.html#graphblas-modes>`__.
+
         """
         how = how.lower()
         if how == "materialize":
@@ -656,6 +667,7 @@ class Vector(BaseType):
         Returns
         -------
         Python scalar
+
         """
         expr = self[index]
         if expr._is_scalar:
@@ -698,6 +710,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         indices = ints_to_numpy_buffer(indices, np.uint64, name="indices")
         values, dtype = values_to_numpy_buffer(values, dtype, subarray_after=1)
@@ -755,6 +768,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         if isinstance(pairs, np.ndarray):
             raise TypeError("pairs as NumPy array is not supported; use `Vector.from_coo` instead")
@@ -806,6 +820,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         if type(value) is not Scalar:
             try:
@@ -858,6 +873,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         values, dtype = values_to_numpy_buffer(values, dtype, subarray_after=1)
         if values.ndim == 0:
@@ -906,6 +922,7 @@ class Vector(BaseType):
         Returns
         -------
         np.ndarray
+
         """
         if fill_value is None or self._nvals == self._size:
             if self._nvals != self._size:
@@ -976,6 +993,7 @@ class Vector(BaseType):
 
             # Functional syntax
             w << monoid.max(u | v)
+
         """
         return self._ewise_add(other, op)
 
@@ -1067,6 +1085,7 @@ class Vector(BaseType):
 
             # Functional syntax
             w << binary.gt(u & v)
+
         """
         return self._ewise_mult(other, op)
 
@@ -1160,6 +1179,7 @@ class Vector(BaseType):
 
             # Functional syntax
             w << binary.div(u | v, left_default=1, right_default=1)
+
         """
         return self._ewise_union(other, op, left_default, right_default)
 
@@ -1314,6 +1334,7 @@ class Vector(BaseType):
 
             # Functional syntax
             C << semiring.min_plus(v @ A)
+
         """
         return self._vxm(other, op)
 
@@ -1393,6 +1414,7 @@ class Vector(BaseType):
 
             # Functional syntax
             w << op.abs(v)
+
         """
         method_name = "apply"
         extra_message = (
@@ -1538,6 +1560,7 @@ class Vector(BaseType):
 
             # Functional syntax
             w << select.value(v >= 1)
+
         """
         method_name = "select"
         if isinstance(op, str):
@@ -1632,6 +1655,7 @@ class Vector(BaseType):
         .. code-block:: python
 
             total << v.reduce(monoid.plus)
+
         """
         method_name = "reduce"
         op = get_typed_op(op, self.dtype, kind="binary|aggregator")
@@ -1684,6 +1708,7 @@ class Vector(BaseType):
         *Note*: This is not a standard GraphBLAS function, but fits with other functions in the
         `Matrix Multiplication <../user_guide/operations.html#matrix-multiply>`__
         family of functions.
+
         """
         return self._inner(other, op)
 
@@ -1739,6 +1764,7 @@ class Vector(BaseType):
             C << v.outer(w, op=binary.times)
 
         *Note*: This is not a standard GraphBLAS function.
+
         """
         from .matrix import MatrixExpression
 
@@ -1787,6 +1813,7 @@ class Vector(BaseType):
         .. code-block:: python
 
             w = v.reposition(20).new()
+
         """
         if size is None:
             size = self._size
@@ -2047,6 +2074,7 @@ class Vector(BaseType):
         Returns
         -------
         Vector
+
         """
         indices = np.fromiter(d.keys(), np.uint64)
         if dtype is None:
@@ -2074,6 +2102,7 @@ class Vector(BaseType):
         Returns
         -------
         dict
+
         """
         indices, values = self.to_coo(sort=False)
         return dict(zip(indices.tolist(), values.tolist()))

--- a/graphblas/io/_awkward.py
+++ b/graphblas/io/_awkward.py
@@ -154,6 +154,7 @@ def from_awkward(A, *, name=None):
     function. If attempting to convert an arbitrary `awkward-array`,
     make sure that the top-level attributes and parameters contain
     the expected values.
+
     """
     params = A.layout.parameters
     if missing := {"format", "shape"} - params.keys():

--- a/graphblas/io/_matrixmarket.py
+++ b/graphblas/io/_matrixmarket.py
@@ -32,6 +32,7 @@ def mmread(source, engine="auto", *, dup_op=None, name=None, **kwargs):
     Returns
     -------
     :class:`~graphblas.Matrix`
+
     """
     try:
         # scipy is currently needed for *all* engines
@@ -95,6 +96,7 @@ def mmwrite(
         Number of digits to write for real or complex values
     symmetry : str, optional
         {"general", "symmetric", "skew-symmetric", "hermetian"}
+
     """
     try:
         # scipy is currently needed for *all* engines

--- a/graphblas/io/_networkx.py
+++ b/graphblas/io/_networkx.py
@@ -21,6 +21,7 @@ def from_networkx(G, nodelist=None, dtype=None, weight="weight", name=None):
     Returns
     -------
     :class:`~graphblas.Matrix`
+
     """
     import networkx as nx
 
@@ -45,6 +46,7 @@ def to_networkx(m, edge_attribute="weight"):
     Returns
     -------
     nx.DiGraph
+
     """
     import networkx as nx
 

--- a/graphblas/io/_scipy.py
+++ b/graphblas/io/_scipy.py
@@ -22,6 +22,7 @@ def from_scipy_sparse(A, *, dup_op=None, name=None):
     Returns
     -------
     :class:`~graphblas.Matrix`
+
     """
     nrows, ncols = A.shape
     dtype = lookup_dtype(A.dtype)

--- a/graphblas/io/_sparse.py
+++ b/graphblas/io/_sparse.py
@@ -23,6 +23,7 @@ def from_pydata_sparse(s, *, dup_op=None, name=None):
     -------
     :class:`~graphblas.Vector`
     :class:`~graphblas.Matrix`
+
     """
     try:
         import sparse

--- a/graphblas/monoid/numpy.py
+++ b/graphblas/monoid/numpy.py
@@ -5,6 +5,7 @@ See list of numpy ufuncs supported by numpy here:
 https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
+
 import numpy as _np
 
 from .. import _STANDARD_OPERATOR_NAMES

--- a/graphblas/select/__init__.py
+++ b/graphblas/select/__init__.py
@@ -88,9 +88,7 @@ def _match_expr(parent, expr):
 
 
 def value(expr):
-    """
-    An advanced select method which allows for easily expressing
-    value comparison logic.
+    """An advanced select method for easily expressing value comparison logic.
 
     Example usage:
     >>> gb.select.value(A > 0)
@@ -102,9 +100,7 @@ def value(expr):
 
 
 def row(expr):
-    """
-    An advanced select method which allows for easily expressing
-    Matrix row index comparison logic.
+    """An advanced select method for easily expressing Matrix row index comparison logic.
 
     Example usage:
     >>> gb.select.row(A <= 5)
@@ -116,9 +112,7 @@ def row(expr):
 
 
 def column(expr):
-    """
-    An advanced select method which allows for easily expressing
-    Matrix column index comparison logic.
+    """An advanced select method for easily expressing Matrix column index comparison logic.
 
     Example usage:
     >>> gb.select.column(A <= 5)
@@ -130,8 +124,7 @@ def column(expr):
 
 
 def index(expr):
-    """
-    An advanced select method which allows for easily expressing
+    """An advanced select method which allows for easily expressing
     Vector index comparison logic.
 
     Example usage:

--- a/graphblas/semiring/numpy.py
+++ b/graphblas/semiring/numpy.py
@@ -5,6 +5,7 @@ See list of numpy ufuncs supported by numpy here:
 https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
+
 import itertools as _itertools
 
 from .. import _STANDARD_OPERATOR_NAMES

--- a/graphblas/ss/_core.py
+++ b/graphblas/ss/_core.py
@@ -22,8 +22,7 @@ _graphblas_ss = _graphblas_ss()
 
 
 def diag(x, k=0, dtype=None, *, name=None, **opts):
-    """
-    GxB_Matrix_diag, GxB_Vector_diag.
+    """GxB_Matrix_diag, GxB_Vector_diag.
 
     Extract a diagonal Vector from a Matrix, or construct a diagonal Matrix
     from a Vector.  Unlike ``Matrix.diag`` and ``Vector.diag``, this function
@@ -71,8 +70,7 @@ def diag(x, k=0, dtype=None, *, name=None, **opts):
 
 
 def concat(tiles, dtype=None, *, name=None, **opts):
-    """
-    GxB_Matrix_concat.
+    """GxB_Matrix_concat.
 
     Concatenate a 2D list of Matrix objects into a new Matrix, or a 1D list of
     Vector objects into a new Vector.  To concatenate into existing objects,

--- a/graphblas/tests/conftest.py
+++ b/graphblas/tests/conftest.py
@@ -68,9 +68,11 @@ def pytest_configure(config):
         for key in dir(gb.semiring)
         if key != "ss"
         and isinstance(
-            getattr(gb.semiring, key)
-            if key not in gb.semiring._deprecated
-            else gb.semiring._deprecated[key],
+            (
+                getattr(gb.semiring, key)
+                if key not in gb.semiring._deprecated
+                else gb.semiring._deprecated[key]
+            ),
             (gb.core.operator.Semiring, gb.core.operator.ParameterizedSemiring),
         )
     )
@@ -79,9 +81,11 @@ def pytest_configure(config):
         for key in dir(gb.binary)
         if key != "ss"
         and isinstance(
-            getattr(gb.binary, key)
-            if key not in gb.binary._deprecated
-            else gb.binary._deprecated[key],
+            (
+                getattr(gb.binary, key)
+                if key not in gb.binary._deprecated
+                else gb.binary._deprecated[key]
+            ),
             (gb.core.operator.BinaryOp, gb.core.operator.ParameterizedBinaryOp),
         )
     )

--- a/graphblas/tests/test_descriptor.py
+++ b/graphblas/tests/test_descriptor.py
@@ -2,8 +2,7 @@ from graphblas.core import descriptor, lib
 
 
 def test_caching():
-    """
-    Test that building a descriptor is actually caching rather than building
+    """Test that building a descriptor is actually caching rather than building
     a new object for each call.
     """
     tocr = descriptor.lookup(

--- a/graphblas/tests/test_dtype.py
+++ b/graphblas/tests/test_dtype.py
@@ -241,7 +241,7 @@ def test_dtype_to_from_string():
 
 
 def test_has_complex():
-    """Only SuiteSparse has complex (with Windows support in Python after v7.4.3.1)"""
+    """Only SuiteSparse has complex (with Windows support in Python after v7.4.3.1)."""
     if not suitesparse:
         assert not dtypes._supports_complex
         return

--- a/graphblas/tests/test_infix.py
+++ b/graphblas/tests/test_infix.py
@@ -346,7 +346,7 @@ def test_inplace_infix(s1, v1, v2, A1, A2):
 
 @autocompute
 def test_infix_expr_value_types():
-    """Test bug where `infix_expr._value` was used as MatrixExpression or Matrix"""
+    """Test bug where `infix_expr._value` was used as MatrixExpression or Matrix."""
     from graphblas.core.matrix import MatrixExpression
 
     A = Matrix(int, 3, 3)

--- a/graphblas/unary/numpy.py
+++ b/graphblas/unary/numpy.py
@@ -5,6 +5,7 @@ See list of numpy ufuncs supported by numpy here:
 https://numba.readthedocs.io/en/stable/reference/numpysupported.html#math-operations
 
 """
+
 import numpy as _np
 
 from .. import _STANDARD_OPERATOR_NAMES

--- a/graphblas/viz.py
+++ b/graphblas/viz.py
@@ -79,6 +79,7 @@ def spy(M, *, centered=False, show=True, figure=None, axes=None, figsize=None, *
     See Also
     --------
     datashade
+
     """
     mpl, plt, ss = _get_imports(["mpl", "plt", "ss"], "spy")
     A = to_scipy_sparse(M, "coo")
@@ -129,6 +130,7 @@ def datashade(M, agg="count", *, width=None, height=None, opts_kwargs=None, **kw
     See Also
     --------
     spy
+
     """
     np, pd, bk, hv, hp, ds = _get_imports(["np", "pd", "bk", "hv", "hp", "ds"], "datashade")
     if "df" not in kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,13 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy >=1.21",
+    "numpy >=1.22",
     "donfig >=0.6",
     "pyyaml >=5.4",
     # These won't be installed by default after 2024.3.0
     # Use e.g. "python-graphblas[suitesparse]" or "python-graphblas[default]" instead
     "suitesparse-graphblas >=7.4.0.0, <9",
-    "numba >=0.55; python_version<'3.12'",  # make optional where numba is not supported
+    "numba >=0.55; python_version<'3.13'",  # make optional where numba is not supported
 ]
 
 [project.urls]
@@ -97,9 +97,9 @@ repr = [
 ]
 io = [
     "python-graphblas[networkx,scipy]",
-    "python-graphblas[numba]; python_version<'3.12'",
+    "python-graphblas[numba]; python_version<'3.13'",
     "awkward >=1.9",
-    "sparse >=0.13; python_version<'3.12'",  # make optional, b/c sparse needs numba
+    "sparse >=0.13; python_version<'3.13'",  # make optional, b/c sparse needs numba
     "fast-matrix-market >=1.4.5",
 ]
 viz = [
@@ -119,11 +119,11 @@ test = [
 ]
 default = [
     "python-graphblas[suitesparse,pandas,scipy]",
-    "python-graphblas[numba]; python_version<'3.12'",  # make optional where numba is not supported
+    "python-graphblas[numba]; python_version<'3.13'",  # make optional where numba is not supported
 ]
 all = [
     "python-graphblas[default,io,viz,test]",
-    "python-graphblas[datashade]; python_version<'3.12'",  # make optional, b/c datashade needs numba
+    "python-graphblas[datashade]; python_version<'3.13'",  # make optional, b/c datashade needs numba
 ]
 
 [tool.setuptools]
@@ -211,6 +211,9 @@ filterwarnings = [
 
     # Python 3.12 introduced this deprecation, which is triggered by pandas 2.1.1
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil",
+
+    # Pandas 2.2 warns that pyarrow will become a required dependency in pandas 3.0
+    "ignore:\\nPyarrow will become a required dependency of pandas:DeprecationWarning:",
 ]
 
 [tool.coverage.run]
@@ -239,6 +242,7 @@ ignore-words-list = "coo,ba"
 # https://github.com/charliermarsh/ruff/
 line-length = 100
 target-version = "py39"
+[tool.ruff.lint]
 unfixable = [
     "F841"  # unused-variable (Note: can leave useless expression)
 ]
@@ -308,23 +312,26 @@ ignore = [
     "D103",  # Missing docstring in public function
     "D104",  # Missing docstring in public package
     "D105",  # Missing docstring in magic method
+    "D107",  # Missing docstring in `__init__`
     # "D107",  # Missing docstring in `__init__`
     "D205",  # 1 blank line required between summary line and description
     "D401",  # First line of docstring should be in imperative mood:
+    "D417",  # D417 Missing argument description in the docstring for ...: ...
     # "D417",  # Missing argument description in the docstring:
     "PLE0605",  # Invalid format for `__all__`, must be `tuple` or `list` (Note: broken in v0.0.237)
 
     # Maybe consider
     # "SIM300",  # Yoda conditions are discouraged, use ... instead (Note: we're not this picky)
     # "SIM401",  # Use dict.get ... instead of if-else-block (Note: if-else better for coverage and sometimes clearer)
+    "B904",  # Use `raise from` to specify exception cause (Note: sometimes okay to raise original exception)
     "TRY004",  # Prefer `TypeError` exception for invalid type (Note: good advice, but not worth the nuisance)
-    "TRY200",  # Use `raise from` to specify exception cause (Note: sometimes okay to raise original exception)
     "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar` (Note: no annotations yet)
     "PERF401",  # Use a list comprehension to create a transformed list (Note: poorly implemented atm)
 
     # Intentionally ignored
     "COM812",  # Trailing comma missing
     "D203",  # 1 blank line required before class docstring (Note: conflicts with D211, which is preferred)
+    "D213",  # (Note: conflicts with D212, which is preferred)
     "D400",  # First line should end with a period (Note: prefer D415, which also allows "?" and "!")
     "N801",  # Class name ... should use CapWords convention (Note:we have a few exceptions to this)
     "N802",  # Function name ... should be lowercase
@@ -374,7 +381,7 @@ ignore = [
     "PD",  # pandas-vet (Intended for scripts that use pandas, not libraries)
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "graphblas/core/operator/base.py" = ["S102"]  # exec is used for UDF
 "graphblas/core/ss/matrix.py" = ["NPY002"]  # numba doesn't support rng generator yet
 "graphblas/core/ss/vector.py" = ["NPY002"]  # numba doesn't support rng generator yet
@@ -389,14 +396,14 @@ ignore = [
 "docs/*.py" = ["INP001"]  # Not a package
 
 
-[tool.ruff.flake8-builtins]
+[tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["copyright", "format", "min", "max"]
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
 
-[tool.ruff.pydocstyle]
+[tool.lint.ruff.pydocstyle]
 convention = "numpy"
 
 [tool.pylint.messages_control]

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -3,15 +3,15 @@
 # Use, adjust, copy/paste, etc. as necessary to answer your questions.
 # This may be helpful when updating dependency versions in CI.
 # Tip: add `--json` for more information.
-conda search 'flake8-bugbear[channel=conda-forge]>=23.12.2'
+conda search 'flake8-bugbear[channel=conda-forge]>=24.1.17'
 conda search 'flake8-simplify[channel=conda-forge]>=0.21.0'
-conda search 'numpy[channel=conda-forge]>=1.26.2'
-conda search 'pandas[channel=conda-forge]>=2.1.4'
-conda search 'scipy[channel=conda-forge]>=1.11.4'
+conda search 'numpy[channel=conda-forge]>=1.26.3'
+conda search 'pandas[channel=conda-forge]>=2.2.0'
+conda search 'scipy[channel=conda-forge]>=1.12.0'
 conda search 'networkx[channel=conda-forge]>=3.2.1'
-conda search 'awkward[channel=conda-forge]>=2.5.1'
-conda search 'sparse[channel=conda-forge]>=0.14.0'
-conda search 'fast_matrix_market[channel=conda-forge]>=1.7.5'
-conda search 'numba[channel=conda-forge]>=0.58.1'
+conda search 'awkward[channel=conda-forge]>=2.5.2'
+conda search 'sparse[channel=conda-forge]>=0.15.1'
+conda search 'fast_matrix_market[channel=conda-forge]>=1.7.6'
+conda search 'numba[channel=conda-forge]>=0.59.0'
 conda search 'pyyaml[channel=conda-forge]>=6.0.1'
 # conda search 'python[channel=conda-forge]>=3.9 *pypy*'


### PR DESCRIPTION
This is just updating versions of dependencies. Some code formatting was updated using the latest `black` and `ruff`. I'll want to stress test the CI given all the new versions of dependencies.

Changes to dependencies:
```
drop
    numpy 1.21
add
    numba 0.59 (supports Python 3.12)
    scipy 1.12
    pandas 2.2
    sparse 0.15
```