### PR TITLE
Move the docs build to ubuntu-24.04 and miniforge3

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -189,7 +189,10 @@ jobs:
             numbaver=NA
             sparse=""
             sparsever=NA
-            if [[ ${{ contains(steps.pyver.outputs.selected, 'pypy') }} ]]; then
+            # Compare explicitly: `[[ false ]]` tests a non-empty string, not a
+            # boolean, so testing the substituted value on its own is always
+            # true. Matches the `== true` form used for the numba skip above.
+            if [[ ${{ contains(steps.pyver.outputs.selected, 'pypy') }} == true ]]; then
               awkward=""
               akver=NA
               npver=""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,9 @@ ci:
   autoupdate_schedule: quarterly
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
-  skip: [pylint, no-commit-to-branch]
+  # pysentry downloads advisory databases at run time, and pre-commit.ci
+  # runs hooks without network access, so it can only run locally.
+  skip: [pylint, no-commit-to-branch, pysentry]
 fail_fast: false
 default_language_version:
   python: python3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,12 +6,13 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: True
 
-# Try to make build faster with mamba. See:
-# https://docs.readthedocs.io/en/stable/guides/conda.html#making-builds-faster-with-mamba
+# Read the Docs dropped the ubuntu-20.04 image, and mambaforge is superseded by
+# miniforge3 (whose conda solves with libmamba anyway). Valid values are listed at:
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
 
 conda:
   environment: docs/env.yml

--- a/graphblas/core/operator/binary.py
+++ b/graphblas/core/operator/binary.py
@@ -653,7 +653,7 @@ class BinaryOp(OpBase):
         # Set JIT C definition for auto-generated built-in UDT ops. Only
         # same-type pairs apply: mixed UDT+scalar ops don't have a
         # meaningful single-type C definition. ``_has_jit_set`` gates access
-        # to ``lib.GrB_BinaryOp_set_String``, which is absent on SS < 8.
+        # to ``lib.GrB_BinaryOp_set_String``, which is absent on SS < 9.
         is_jittable = self.name in _BUILTIN_UDT_BINARY_OPS or self.name in ("eq", "ne")
         if _has_numba and _has_jit_set and dtype == dtype2 and is_jittable:
             if self.name in _BUILTIN_UDT_BINARY_OPS:

--- a/graphblas/core/operator/unary.py
+++ b/graphblas/core/operator/unary.py
@@ -122,6 +122,7 @@ def _one(x):
 if _has_numba:
     from .udt_utils import BUILTIN_UDT_UNARY_OPS as _BUILTIN_UDT_UNARY_OPS
     from .udt_utils import (
+        _has_jit_set,
         _maybe_warn_jit_skipped,
         compile_udt_unary_wrapper,
         set_jit_c_on_op,
@@ -264,12 +265,14 @@ class UnaryOp(OpBase):
             op = _finalize_udt_op(
                 self, dtype, None, ret_type, unary_wrapper, wrapper_sig, TypedUserUnaryOp
             )
-            # ``set_jit_c_on_op`` is a no-op (returns None) when
-            # ``_has_jit_set`` is False (SS < 8).
-            op._jit_c_info = set_jit_c_on_op(
-                op.gb_obj, self.name, py_op, dtype, lib.GrB_UnaryOp_set_String, arity=1
-            )
-            _maybe_warn_jit_skipped(op._jit_c_info, self.name, dtype.name)
+            # ``_has_jit_set`` gates access to ``lib.GrB_UnaryOp_set_String``,
+            # which is absent on SS < 9; the attribute lookup itself raises
+            # there, so it must not be evaluated as an argument first.
+            if _has_jit_set:
+                op._jit_c_info = set_jit_c_on_op(
+                    op.gb_obj, self.name, py_op, dtype, lib.GrB_UnaryOp_set_String, arity=1
+                )
+                _maybe_warn_jit_skipped(op._jit_c_info, self.name, dtype.name)
             return op
         if self._numba_func is None:
             raise KeyError(f"{self.name} does not work with {dtype}")

--- a/graphblas/io/_matrixmarket.py
+++ b/graphblas/io/_matrixmarket.py
@@ -42,6 +42,7 @@ def mmread(source, engine="auto", *, dup_op=None, name=None, **kwargs):
     except ImportError:  # pragma: no cover (import)
         raise ImportError("scipy is required to read Matrix Market files") from None
     engine = engine.lower()
+    using_scipy = True
     if engine in {"fmm", "fast_matrix_market"}:
         warnings.warn(
             "fast_matrix_market is no longer maintained and will be removed in a future version. "
@@ -67,10 +68,24 @@ def mmread(source, engine="auto", *, dup_op=None, name=None, **kwargs):
                     "fast_matrix_market is required to read Matrix Market files "
                     f'using the "{engine}" engine'
                 ) from None
+        else:
+            using_scipy = False
     elif engine != "scipy":
         raise ValueError(
             f'Bad engine value: {engine!r}. Must be "auto", "scipy", "fmm", or "fast_matrix_market"'
         )
+    if using_scipy and "spmatrix" not in kwargs:
+        # scipy's `mmread` still returns a sparse matrix by default, but 1.18
+        # deprecated that default and 1.20 flips it to a sparse array. We only
+        # read `.shape`, `.row`, `.col`, and `.data` below, which both types
+        # provide, so ask for the future default and skip the warning.
+        # MAINT: 2026-07-31 once we require scipy >= 1.20 this whole block goes
+        # away, since False becomes the default.
+        # Older scipy has no such argument; check rather than pin a version.
+        import inspect
+
+        if "spmatrix" in inspect.signature(mmread).parameters:
+            kwargs["spmatrix"] = False
     array = mmread(source, **kwargs)
     if getattr(array, "format", None) == "coo":
         nrows, ncols = array.shape

--- a/graphblas/tests/test_dtype.py
+++ b/graphblas/tests/test_dtype.py
@@ -419,6 +419,8 @@ def test_dtype_to_from_string():
             assert dtype == dtype2
 
 
+# The 180-char repr exceeds GxB_MAX_NAME_LEN, which warns on SuiteSparse < 9.
+@pytest.mark.filterwarnings("ignore:UDT repr is too large")
 def test_dtype_to_string_aligned_outer_packed_inner():
     """Regression: nested dtype with ``align=True`` outer and a packed inner
     used to fail ``_dtype_to_string`` round-trip with ``ValueError: Unable

--- a/graphblas/tests/test_indexbinary.py
+++ b/graphblas/tests/test_indexbinary.py
@@ -354,8 +354,10 @@ def test_bound_ibo_memory_bounded():
     growth should stay below a few MB after GC drops them.
     """
     import gc
-    import resource
     import sys
+
+    pytest.importorskip("resource")
+    import resource
 
     if hasattr(indexbinary, "leak_test_bound_ibo_op"):
         delattr(indexbinary, "leak_test_bound_ibo_op")

--- a/graphblas/tests/test_io.py
+++ b/graphblas/tests/test_io.py
@@ -1,3 +1,4 @@
+import functools
 from io import BytesIO, StringIO
 
 import numpy as np
@@ -302,6 +303,42 @@ def test_mmread_mmwrite(engine):
                 raise AssertionError("Matrix M2 not as expected.  See print output above")
         success += 1
     assert success > 0
+
+
+@pytest.mark.skipif("not ss")
+def test_mmread_asks_scipy_for_a_sparse_array(monkeypatch):
+    """We pass ``spmatrix=False`` so scipy's changing default never reaches us.
+
+    Deliberately does not use scipy's own example files: they are absent from
+    some conda-forge builds, which skips ``test_mmread_mmwrite`` entirely.
+    """
+    import inspect
+
+    import scipy.io as sio
+
+    if "spmatrix" not in inspect.signature(sio.mmread).parameters:  # pragma: no cover (old scipy)
+        pytest.skip("scipy too old to accept spmatrix=")
+
+    seen = []
+    real = sio.mmread
+
+    @functools.wraps(real)  # keep the signature the caller inspects
+    def spy(source, **kwargs):
+        seen.append(kwargs)
+        return real(source, **kwargs)
+
+    monkeypatch.setattr(sio, "mmread", spy)
+    mm = StringIO("%%MatrixMarket matrix coordinate real general\n2 2 2\n1 1 3.0\n2 2 4.0\n")
+    M = gb.io.mmread(mm)
+
+    assert seen == [{"spmatrix": False}]
+    assert M.isequal(Matrix.from_coo([0, 1], [0, 1], [3.0, 4.0]))
+
+    # An explicit value wins: the guard only fills in a default.
+    seen.clear()
+    mm.seek(0)
+    gb.io.mmread(mm, spmatrix=True)
+    assert seen == [{"spmatrix": True}]
 
 
 @pytest.mark.skipif("not ss")

--- a/graphblas/tests/test_op.py
+++ b/graphblas/tests/test_op.py
@@ -28,6 +28,7 @@ from graphblas.core.operator import (
     UnaryOp,
     get_semiring,
 )
+from graphblas.core.ss import version_major as ss_version_major  # noqa: F401 (used in skipif)
 from graphblas.dtypes import (
     BOOL,
     FP32,
@@ -1973,6 +1974,15 @@ def test_udt_op_compilation_is_lazy():
 
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
+# A SuiteSparse compiled without variable-length arrays (MSVC, so the Windows
+# builds) rejects a user-defined type larger than GB_VLA_MAXSIZE with
+# GrB_INVALID_VALUE. That ceiling was 128 bytes through SS 8.x and is 1024 as
+# of 9.0, so skipping on SS < 9 covers the affected builds and costs one test
+# on the rest.
+@pytest.mark.skipif(
+    "ss_version_major < 9",
+    reason="SuiteSparse < 9 rejects an 800-byte UDT on builds without VLA support",
+)
 def test_udt_large_array():
     big_dtype = np.dtype((np.float64, (100,)))
     big_udt = dtypes.register_anonymous(big_dtype)
@@ -2069,6 +2079,10 @@ def test_udt_eq_packed_mixed_width():
 
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
+# SS < 9 has no GrB_NAME setter, so registration falls back to storing the
+# numpy repr in the type name and warns when it does not fit in 128 chars.
+# This dtype's repr is 133; how it serializes is not what the test is about.
+@pytest.mark.filterwarnings("ignore:UDT repr is too large")
 def test_udt_eq_nested_record_with_nan_leaf():
     """A NaN in a nested-record leaf still makes the outer record compare unequal."""
     nested = np.dtype(
@@ -2303,6 +2317,8 @@ def test_udt_eq_ne_scalar_broadcast_array_2d():
 
 @pytest.mark.skipif("not supports_udfs")
 @pytest.mark.slow
+# 131-char numpy repr; see test_udt_eq_nested_record_with_nan_leaf.
+@pytest.mark.filterwarnings("ignore:UDT repr is too large")
 def test_udt_eq_ne_scalar_broadcast_nested_record():
     inner = np.dtype([("a", np.float64), ("b", np.float64)], align=True)
     nested = dtypes.register_anonymous(

--- a/graphblas/tests/test_ssjit.py
+++ b/graphblas/tests/test_ssjit.py
@@ -962,8 +962,8 @@ def test_anonymous_udt_with_no_name_still_jits():
     alone for Python-side display. If that fallback regresses, the op runs
     through the slower Numba cfunc path and ``jit_c_source`` is ``None``.
     """
-    if _IS_SSGB7:
-        pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
+    if not _has_jit_set:
+        pytest.skip("jit_c_* introspection requires SuiteSparse:GraphBLAS >= 9")
     _require_jit_on()
 
     spec = np.dtype([("anon_a", np.float64), ("anon_b", np.int64)], align=True)
@@ -1005,8 +1005,8 @@ def test_complex_field_udt_jits_arithmetic():
     without extra includes. ``abs`` uses ``cabs`` / ``cabsf`` which match
     Numba's ``abs(complex)`` behavior (real magnitude in the real part).
     """
-    if _IS_SSGB7:
-        pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
+    if not _has_jit_set:
+        pytest.skip("jit_c_definition introspection requires SuiteSparse:GraphBLAS >= 9")
     _require_jit_on()
 
     spec = np.dtype([("cval", np.complex128), ("scale", np.float64)])
@@ -1117,8 +1117,8 @@ def test_nested_record_udt_jits():
     the nested record fields (Numba can't ``setitem`` a tuple to a record
     field, but leaf scalar writes work).
     """
-    if _IS_SSGB7:
-        pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
+    if not _has_jit_set:
+        pytest.skip("jit_c_definition introspection requires SuiteSparse:GraphBLAS >= 9")
     _require_jit_on()
 
     # ``align=True`` is required for mixed-width fields so numpy's offsets
@@ -1314,8 +1314,8 @@ def test_eq_ne_udt_jit_matches_cfunc(shape):
     record, complex, array UDT), and that NaN propagation matches IEEE
     (``eq(NaN, NaN) == False``) on variants flagged ``nan_at_zero``.
     """
-    if _IS_SSGB7:
-        pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
+    if not _has_jit_set:
+        pytest.skip("attaching the UDT JIT kernel requires SuiteSparse:GraphBLAS >= 9")
     _require_jit_on()
     if numba is None:
         pytest.skip("numba required for the cfunc baseline")

--- a/graphblas/tests/test_ssjit.py
+++ b/graphblas/tests/test_ssjit.py
@@ -21,6 +21,7 @@ from graphblas import (
 )
 from graphblas.core import _supports_udfs as supports_udfs
 from graphblas.core.operator.indexbinary import _has_idxbinop
+from graphblas.core.operator.udt_utils import _has_jit_set
 from graphblas.core.ss import _IS_SSGB7
 
 from .conftest import autocompute, burble
@@ -537,7 +538,9 @@ def test_jit_select(v):
 
 
 @pytest.mark.skipif("not supports_udfs")
-@pytest.mark.skipif("_IS_SSGB7")
+# The JIT string setters (GrB_Type_set_String with GxB_JIT_C_NAME) arrived in
+# SS 9, so every jit_c_* property is None on 7.x and 8.x alike.
+@pytest.mark.skipif("not _has_jit_set")
 def test_udt_jit_c_source_introspection():
     """``jit_c_source`` and ``jit_c_name`` should expose what SS sees.
 
@@ -606,7 +609,8 @@ def test_udt_jit_c_source_introspection():
 
 
 @pytest.mark.skipif("not supports_udfs")
-@pytest.mark.skipif("_IS_SSGB7")
+# jit_c_name is only ever set on SS 9+; see test_udt_jit_c_source_introspection.
+@pytest.mark.skipif("not _has_jit_set")
 def test_op_jit_signature_uses_pinned_type_name():
     """After a UDT is renamed, auto-lifted ops must still reference the
     pinned (first-registration) C name in their signature. SS's
@@ -1167,6 +1171,10 @@ def test_nested_record_udt_jits():
 
 @pytest.mark.slow
 @pytest.mark.skipif("not supports_udfs")
+# SS < 9 has no GrB_NAME setter, so registration falls back to storing the
+# numpy repr in the type name and warns when it does not fit in 128 chars.
+# This dtype's repr is 141; how it serializes is not what the test is about.
+@pytest.mark.filterwarnings("ignore:UDT repr is too large")
 def test_nested_record_monoid_semiring_agg():
     r"""Built-in monoid/semiring/agg auto-lift on nested record UDTs.
 
@@ -1385,8 +1393,10 @@ def test_udt_scalar_broadcast_skips_jit():
     routing so a future change doesn't accidentally regress it (either
     direction is fine, but it should be a conscious decision).
     """
-    if _IS_SSGB7:
-        pytest.skip("JIT requires SuiteSparse:GraphBLAS >= 8")
+    if not _has_jit_set:
+        # Without the SS 9 string setters, jit_c_source is None for every op,
+        # so there is no routing to observe.
+        pytest.skip("requires SuiteSparse:GraphBLAS >= 9")
     record = dtypes.register_anonymous(
         np.dtype([("bcast_u", np.float64), ("bcast_v", np.float64)], align=True),
         name="_BcastJitUV",

--- a/graphblas/tests/test_vector.py
+++ b/graphblas/tests/test_vector.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 import graphblas as gb
 from graphblas import agg, backend, binary, dtypes, indexunary, monoid, select, semiring, unary
 from graphblas.core import _supports_udfs as supports_udfs
+from graphblas.core import lib
 from graphblas.exceptions import (
     DimensionMismatch,
     DomainMismatch,
@@ -2220,8 +2221,13 @@ def test_udt():
     if suitesparse:
         vv = Vector.ss.deserialize(v.ss.serialize(), dtype=long_udt)
         assert v.isequal(vv, check_dtype=True)
-        with pytest.raises(SyntaxError):
-            # The dtype name is too long to embed in the blob; dtype= must be provided
+        # The dtype name is too long to embed in the blob; dtype= must be provided.
+        # Whichever error the caller sees comes from parsing the name that is in
+        # the blob. Builds with GxB_Serialized_get_String let that SyntaxError
+        # through; older ones have no second name to try, so they wrap it.
+        with pytest.raises(
+            SyntaxError if hasattr(lib, "GxB_Serialized_get_String") else ValueError
+        ):
             Vector.ss.deserialize(v.ss.serialize())
     # May be able to look up non-anonymous dtypes by name if their names are too long
     named_long_dtype = np.dtype([("x", np.bool_), ("y" * 1000, np.float64)], align=False)

--- a/scripts/check_versions.sh
+++ b/scripts/check_versions.sh
@@ -12,7 +12,7 @@ conda search 'numpy[channel=conda-forge]>=2.4'
 conda search 'pandas[channel=conda-forge]>=3.0'
 conda search 'scipy[channel=conda-forge]>=1.17'
 conda search 'networkx[channel=conda-forge]>=3.6'
-conda search 'awkward[channel=conda-forge]>=2.9'
+conda search 'awkward[channel=conda-forge]>=2.11'
 conda search 'sparse[channel=conda-forge]>=0.15'
 # fast_matrix_market is deprecated (no longer maintained; last supported Python is 3.12)
 conda search 'numba[channel=conda-forge]>=0.64'

--- a/scripts/ci_pick_versions.py
+++ b/scripts/ci_pick_versions.py
@@ -144,6 +144,8 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
     then Python-version constraints, then numba/numpy constraints. Within the awkward
     section, the numpy 2.x floor runs before the Python-availability picks (which may
     narrow the choices further), and the awkward >=2.10 rule runs last so it wins.
+    The networkx section reads numpy, scipy, and pandas, so it runs after all three
+    are final.
     """
     # --- scipy / numpy constraints ---
 
@@ -218,6 +220,22 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
         and _ver(v["awkward"]) < (2, 10)
     ):
         v["awkward"] = random.choice([a for a in AWKWARD_VERSIONS["2.x"] if _ver(a) >= (2, 10)])
+
+    # --- networkx / numpy, scipy, pandas floors ---
+
+    # conda-forge networkx 3.5 and 3.6 declare `constrains: numpy >=1.25, scipy >=1.11.2,
+    # pandas >=2.0`. conda enforces those against our pins, and since networkx is pinned too
+    # the solve fails outright instead of backing off. Older pins are safe because a pin like
+    # "3.4" can resolve down to 3.4.0, whose floors (numpy >=1.22, scipy >=1.9, pandas >=1.4)
+    # sit at or below everything in our pools. Unpinned networkx is latest, so it gets the
+    # 3.5+ floors. Compare scipy at the minor level: the "1.11" pin resolves to 1.11.4, which
+    # clears the 1.11.2 floor.
+    # MAINT: 2026-08-04 conda-forge networkx 3.6.1 constrains numpy >=1.25, scipy >=1.11.2
+    if _ver(v["networkx"]) >= (3, 5) and (
+        _ver(v["numpy"]) < (1, 25) or _ver(v["scipy"]) < (1, 11) or _ver(v["pandas"]) < (2, 0)
+    ):
+        # Only the numpy 1.x pools reach here, and those Pythons all have pre-3.5 networkx.
+        v["networkx"] = random.choice([n for n in NETWORKX_VERSIONS[pyver] if _ver(n) < (3, 5)])
 
     # --- numba constraints ---
 
@@ -471,6 +489,17 @@ def validate(v, pyver):
         and _ver(v["awkward"]) < (2, 10)
     ):
         errors.append(f"awkward {v['awkward']} requires numpy <2.5, got {v['numpy'] or 'latest'}")
+
+    # networkx >=3.5 constrains numpy >=1.25, scipy >=1.11.2 (the "1.11" pin clears it),
+    # and pandas >=2.0
+    if _ver(v["networkx"]) >= (3, 5):
+        nx = v["networkx"] or "latest"
+        if _ver(v["numpy"]) < (1, 25):
+            errors.append(f"networkx {nx} requires numpy >=1.25, got {v['numpy']}")
+        if _ver(v["scipy"]) < (1, 11):
+            errors.append(f"networkx {nx} requires scipy >=1.11.2, got {v['scipy']}")
+        if _ver(v["pandas"]) < (2, 0):
+            errors.append(f"networkx {nx} requires pandas >=2.0, got {v['pandas']}")
 
     # numba Python minimums
     numba_min = {"3.11": (0, 57), "3.12": (0, 59), "3.13": (0, 61), "3.14": (0, 63)}

--- a/scripts/ci_pick_versions.py
+++ b/scripts/ci_pick_versions.py
@@ -50,12 +50,15 @@ PANDAS_VERSIONS = {
     "2.x": ["2.2", "2.3", "3.0", ""],
 }
 
+# The "2.x" pool starts at 2.6 because awkward <2.6 still uses numpy.AxisError,
+# which numpy 2.0 removed. 2.10 and 2.11 are the only pins that survive numpy >=2.5;
+# see the awkward constraints in `apply_constraints`.
 AWKWARD_VERSIONS = {
     "1.x": {
         "3.11": ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", ""],
         "3.12": ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", ""],
     },
-    "2.x": ["2.6", "2.7", "2.8", "2.9", ""],
+    "2.x": ["2.6", "2.7", "2.8", "2.9", "2.10", "2.11", ""],
 }
 
 NUMBA_VERSIONS = {
@@ -138,7 +141,9 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
 
     Each constraint comment documents the real-world requirement it encodes.
     Order matters: numpy/scipy constraints first, then pandas (which may bump scipy/numba),
-    then Python-version constraints, then numba/numpy constraints.
+    then Python-version constraints, then numba/numpy constraints. Within the awkward
+    section, the numpy 2.x floor runs before the Python-availability picks (which may
+    narrow the choices further), and the awkward >=2.10 rule runs last so it wins.
     """
     # --- scipy / numpy constraints ---
 
@@ -184,6 +189,15 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
         if v["scipy"] not in ("", "NA") and _ver(v["scipy"]) < (1, 15):
             v["scipy"] = random.choice(["1.15", "1.16", "1.17", ""])
 
+    # --- awkward / numpy 2.x support ---
+
+    # awkward <2.6 uses numpy.AxisError, which numpy 2.0 removed (test_io.py then fails
+    # at collection). awkward is picked from the numpy 1.x pool before source builds blank
+    # numpy to latest, so a numpy 1.x pick can still end up here with numpy 2.x.
+    # MAINT: 2026-08-04 confirmed with awkward 2.0.10 + numpy 2.4
+    if not np_is_1x and v["awkward"] not in ("", "NA") and _ver(v["awkward"]) < (2, 6):
+        v["awkward"] = random.choice(AWKWARD_VERSIONS["2.x"])
+
     # --- awkward / Python version availability ---
 
     # awkward <2.7 has no py3.13 builds; awkward <2.8 has no py3.14 builds
@@ -191,6 +205,19 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
         v["awkward"] = random.choice(["2.8", "2.9", ""])
     elif pyver == "3.13" and v["awkward"] == "2.6":
         v["awkward"] = random.choice(["2.7", "2.8", "2.9", ""])
+
+    # --- awkward / numpy 2.5 deprecations ---
+
+    # awkward <2.10 builds numpy.datetime64("NaT") with a generic unit at import time,
+    # which numpy 2.5 deprecates; `filterwarnings = error` in pyproject.toml then turns the
+    # import into a collection error. Unpinned numpy is latest, which is >=2.5.
+    # MAINT: 2026-08-04 confirmed with awkward 2.8.12 and 2.9.0 + numpy 2.5
+    if (
+        _ver(v["numpy"]) >= (2, 5)
+        and v["awkward"] not in ("", "NA")
+        and _ver(v["awkward"]) < (2, 10)
+    ):
+        v["awkward"] = random.choice([a for a in AWKWARD_VERSIONS["2.x"] if _ver(a) >= (2, 10)])
 
     # --- numba constraints ---
 
@@ -432,6 +459,18 @@ def validate(v, pyver):
         errors.append(f"awkward {v['awkward']} has no py3.14 build")
     if pyver == "3.13" and v["awkward"] == "2.6":
         errors.append("awkward 2.6 has no py3.13 build")
+
+    # awkward <2.6 requires numpy 1.x (numpy.AxisError)
+    if not np_is_1x and v["awkward"] not in ("", "NA") and _ver(v["awkward"]) < (2, 6):
+        errors.append(f"awkward {v['awkward']} doesn't support numpy 2.x")
+
+    # awkward <2.10 requires numpy <2.5 (generic-unit datetime64("NaT") at import)
+    if (
+        _ver(v["numpy"]) >= (2, 5)
+        and v["awkward"] not in ("", "NA")
+        and _ver(v["awkward"]) < (2, 10)
+    ):
+        errors.append(f"awkward {v['awkward']} requires numpy <2.5, got {v['numpy'] or 'latest'}")
 
     # numba Python minimums
     numba_min = {"3.11": (0, 57), "3.12": (0, 59), "3.13": (0, 61), "3.14": (0, 63)}


### PR DESCRIPTION
Read the Docs no longer offers the ubuntu-20.04 build image, so the docs
build fails before it reaches sphinx. `build.os` now accepts ubuntu-22.04,
ubuntu-24.04, ubuntu-26.04, and ubuntu-lts-latest.

`mambaforge-4.10` is still accepted but is marked deprecated, and the
mambaforge series is superseded by miniforge3, whose conda solves with
libmamba anyway. The comment the old pin carried (mamba makes builds
faster) no longer describes a difference.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>