### PR TITLE
Read a nested array UDT scalar at its full extent

### DIFF
--- a/graphblas/core/scalar.py
+++ b/graphblas/core/scalar.py
@@ -356,7 +356,16 @@ class Scalar(BaseType):
             rv = np.array(ffi.buffer(scalar.gb_obj[0 : np_type.itemsize]))
             if np_type.subdtype is None:
                 return rv.view(np_type)[0]
-            return rv.view(np_type.subdtype[0]).reshape(np_type.subdtype[1])
+            # Collapse nested subarray dtypes before viewing. numpy keeps them
+            # layered, so a 6-long array of 5-long FP64 arrays has
+            # ``subdtype == (dtype(('<f8', (5,))), (6,))``; viewing all 240
+            # bytes as that 40-byte subarray dtype raises instead of reading
+            # the element.
+            base, shape = np_type.subdtype
+            while base.subdtype is not None:
+                inner_base, inner_shape = base.subdtype
+                base, shape = inner_base, shape + inner_shape
+            return rv.view(base).reshape(shape)
         return scalar.gb_obj[0]
 
     @value.setter

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -248,6 +248,28 @@ def test_udt_scalar_padding_is_zeroed():
     assert raw == Scalar.from_value((3, 4.0), dtype=udt).value.tobytes()
 
 
+def test_udt_scalar_nested_array_roundtrip():
+    """A UDT whose element is itself an array dtype reads back at full extent.
+
+    numpy keeps subarray dtypes layered rather than flattening them, so a
+    6-long array of 5-long FP64 arrays reports ``subdtype`` as a 40-byte inner
+    dtype with shape ``(6,)``. Viewing all 240 bytes as that inner dtype raised
+    ValueError: "Changing the dtype to a subarray type is only supported if the
+    total itemsize is unchanged".
+    """
+    inner = np.dtype((np.float64, (5,)))
+    udt = dtypes.register_anonymous(np.dtype((inner, (6,))), "_NestedArrayUdt")
+    assert udt.np_type.itemsize == 240
+    assert udt.np_type.subdtype[0].subdtype is not None  # genuinely nested
+
+    val = np.arange(30, dtype=np.float64).reshape(6, 5)
+    got = Scalar.from_value(val, dtype=udt).value
+    # Assert the values, not just that it did not raise: a wrong collapse
+    # produces a correctly-shaped but transposed array.
+    assert got.shape == (6, 5)
+    np.testing.assert_array_equal(got, val)
+
+
 def test_nvals(s):
     assert s.nvals == 1
     s.clear()

--- a/graphblas/tests/test_scalar.py
+++ b/graphblas/tests/test_scalar.py
@@ -10,6 +10,7 @@ import pytest
 
 import graphblas as gb
 from graphblas import backend, binary, dtypes, monoid, replace, select, unary
+from graphblas.core.ss import version_major as ss_version_major  # noqa: F401 (used in skipif)
 from graphblas.exceptions import EmptyObject
 
 from .conftest import autocompute, compute, pypy
@@ -248,6 +249,15 @@ def test_udt_scalar_padding_is_zeroed():
     assert raw == Scalar.from_value((3, 4.0), dtype=udt).value.tobytes()
 
 
+# A SuiteSparse compiled without variable-length arrays (MSVC, so the Windows
+# builds) rejects a user-defined type larger than GB_VLA_MAXSIZE with
+# GrB_INVALID_VALUE. That ceiling was 128 bytes through SS 8.x and is 1024 as
+# of 9.0, so skipping on SS < 9 covers the affected builds and costs one test
+# on the rest.
+@pytest.mark.skipif(
+    "ss_version_major < 9",
+    reason="SuiteSparse < 9 rejects a 240-byte UDT on builds without VLA support",
+)
 def test_udt_scalar_nested_array_roundtrip():
     """A UDT whose element is itself an array dtype reads back at full extent.
 


### PR DESCRIPTION
numpy keeps subarray dtypes layered instead of flattening them, so a UDT
holding a 6-long array of 5-long FP64 arrays reports `subdtype` as a 40-byte
inner dtype with shape `(6,)` rather than FP64 with shape `(6, 5)`. Viewing
all 240 bytes of the scalar as that inner dtype raised

    ValueError: Changing the dtype to a subarray type is only supported if
    the total itemsize is unchanged

so reading `.value` on such a scalar failed outright.

Walk the `subdtype` chain to the base element type, accumulating the shape,
and view once at the bottom. The test asserts the values rather than only
that the read succeeds, because a wrong collapse yields a correctly-shaped
but transposed array.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>