### PR TITLE
Keep the CI matplotlib pick compatible with the numpy pick

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -222,7 +222,7 @@ jobs:
             pyyaml${yamlver} ${sparse} pandas${pdver} scipy${spver} numpy${npver} ${awkward} \
             networkx${nxver} ${numba} ${psg} \
             ${{ matrix.slowtask == 'pytest_bizarro' && 'black' || '' }} \
-            ${{ matrix.slowtask == 'notebooks' && 'matplotlib nbconvert jupyter "ipython>=7" drawsvg' || '' }} \
+            ${{ matrix.slowtask == 'notebooks' && '"matplotlib${mplver}" nbconvert jupyter "ipython>=7" drawsvg' || '' }} \
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \
             ${{ steps.sourcetype.outputs.selected != 'wheel' && '"graphblas>=7.4"' || '' }} \
             ${{ contains(steps.pyver.outputs.selected, 'pypy') && 'pypy' || '' }} \

--- a/scripts/ci_pick_versions.py
+++ b/scripts/ci_pick_versions.py
@@ -237,6 +237,19 @@ def apply_constraints(v, pyver, scipy_pool, numba_pool):
         # Only the numpy 1.x pools reach here, and those Pythons all have pre-3.5 networkx.
         v["networkx"] = random.choice([n for n in NETWORKX_VERSIONS[pyver] if _ver(n) < (3, 5)])
 
+    # --- matplotlib / numpy floor (notebooks job) ---
+
+    # matplotlib is installed unpinned for the notebooks task. matplotlib 3.11.0's
+    # runtime check requires numpy >=1.25, but its conda-forge metadata does not,
+    # so the solver happily pairs matplotlib 3.11 with a numpy 1.24 pin and the
+    # notebooks then die at `import matplotlib`. Pin below 3.11 whenever the
+    # numpy pick sits under that floor; empty means latest is fine.
+    # MAINT: 2026-08-05 confirmed with matplotlib 3.11.0 + numpy 1.24.4
+    if v["numpy"] and _ver(v["numpy"]) < (1, 25):
+        v["matplotlib"] = "<3.11"
+    else:
+        v["matplotlib"] = ""
+
     # --- numba constraints ---
 
     # numba minimum by Python version: 0.59 for 3.12, 0.61 for 3.13, 0.63 for 3.14
@@ -380,6 +393,7 @@ _SUMMARY_NAMES = {
     "sparse": "sparse",
     "numba": "numba",
     "psg": "psg",
+    "matplotlib": "mpl",
 }
 
 
@@ -401,6 +415,8 @@ def format_output(v):
 
     # psg already has = or == prefix
     lines.append(f"psgver='{v['psg']}'")
+    # matplotlib carries a bare ceiling (e.g. "<3.11") or is empty for latest
+    lines.append(f"mplver='{v['matplotlib']}'")
     return "\n".join(lines)
 
 
@@ -417,6 +433,7 @@ def format_summary(v):
         "pyyaml",
         "sparse",
         "psg",
+        "matplotlib",
     ):
         name = _SUMMARY_NAMES[key]
         val = v[key]
@@ -481,6 +498,10 @@ def validate(v, pyver):
     # awkward <2.6 requires numpy 1.x (numpy.AxisError)
     if not np_is_1x and v["awkward"] not in ("", "NA") and _ver(v["awkward"]) < (2, 6):
         errors.append(f"awkward {v['awkward']} doesn't support numpy 2.x")
+
+    # matplotlib 3.11 requires numpy >=1.25 at runtime (notebooks job)
+    if v["numpy"] and _ver(v["numpy"]) < (1, 25) and v.get("matplotlib", "") != "<3.11":
+        errors.append(f"matplotlib unpinned alongside numpy {v['numpy']} (needs <3.11)")
 
     # awkward <2.10 requires numpy <2.5 (generic-unit datetime64("NaT") at import)
     if (


### PR DESCRIPTION
Stacked on #620. The overnight matrix produced the post-restack wave's first two failures, both identical: `build_and_test (macos-latest, notebooks)` on `33-udf-ret-dtype` and `build_and_test (windows-latest, notebooks)` on `27-check-mask-move` failed at `import matplotlib` with

```
ImportError: Matplotlib requires numpy>=1.25; you have 1.24.4
```

The random dependency picker chose numpy 1.24 while the notebooks task installs matplotlib unpinned; matplotlib 3.11.0's runtime check requires numpy >=1.25 but its conda-forge metadata does not carry that floor, so the solver pairs them and the job dies at import. Not a code bug in either PR; any rung can draw this combination in the notebooks lane.

Same class and fix shape as the existing networkx and awkward pick constraints (`3a065ba9`, `8c741ce9`): `ci_pick_versions.py` now emits `mplver` (a bare `<3.11` ceiling when the numpy pick sits under 1.25, empty otherwise), the notebooks install line consumes it, and `validate()` checks the pairing. `--validate` passes 160,000 combos with zero failures; both emission cases confirmed by running the picker.

Gates: full pinned suite 1114 passed / 145 skipped; pre-commit all hooks pass.