### PR TITLE
Pick CI's random matrix values with bash instead of a marketplace action

### DIFF
--- a/.github/workflows/imports.yml
+++ b/.github/workflows/imports.yml
@@ -13,32 +13,22 @@ jobs:
       os: ${{ steps.os.outputs.selected }}
       pyver: ${{ steps.pyver.outputs.selected }}
     steps:
+      # Plain bash instead of a marketplace action; see the note on the rngs job in
+      # test_and_build.yml. To weight a choice, repeat it; to skip one, remove it.
       - name: RNG for os
-        uses: ddradar/choose-random-action@v4.1.0
         id: os
-        with:
-          contents: |
-            ubuntu-latest
-            macos-latest
-            windows-latest
-          weights: |
-            1
-            1
-            1
+        run: |
+          choices=(ubuntu-latest macos-latest windows-latest)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
       - name: RNG for Python version
-        uses: ddradar/choose-random-action@v4.1.0
         id: pyver
-        with:
-          contents: |
-            3.11
-            3.12
-            3.13
-            3.14
-          weights: |
-            1
-            1
-            1
-            1
+        run: |
+          choices=(3.11 3.12 3.13 3.14)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
   test_imports:
     needs: rngs
     runs-on: ${{ needs.rngs.outputs.os }}

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -49,34 +49,25 @@ jobs:
       mapnumpy: ${{ steps.mapnumpy.outputs.selected }}
       backend: ${{ steps.backend.outputs.selected }}
     steps:
+      # Plain bash instead of a marketplace action: resolving a third-party action is a
+      # network dependency that has failed with repeated 5xx errors ("Internal Server Error
+      # occurred while resolving ddradar/choose-random-action"), and a failure here kills
+      # the whole matrix. To weight a choice, repeat it (e.g. `A A B` picks A twice as
+      # often); to skip a choice, remove it from the list.
       - name: RNG for mapnumpy
-        uses: ddradar/choose-random-action@v4.1.0
         id: mapnumpy
-        with:
-          contents: |
-            A
-            B
-            C
-            D
-          weights: |
-            1
-            1
-            1
-            1
+        run: |
+          choices=(A B C D)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
       - name: RNG for backend
-        uses: ddradar/choose-random-action@v4.1.0
         id: backend
-        with:
-          contents: |
-            E
-            F
-            G
-            H
-          weights: |
-            1
-            1
-            1
-            1
+        run: |
+          choices=(E F G H)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
   build_and_test:
     needs: rngs
     runs-on: ${{ matrix.os }}
@@ -118,39 +109,26 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      # Plain bash instead of a marketplace action; see the note on the rngs job above.
+      # To weight a choice, repeat it; to skip a choice, remove it from the list.
       - name: RNG for Python version
-        uses: ddradar/choose-random-action@v4.1.0
         id: pyver
-        with:
-          # We should support major Python versions for at least 36 months as per SPEC 0
-          # We may be able to support pypy if anybody asks for it
-          # 3.9.16 0_73_pypy
-          contents: |
-            3.11
-            3.12
-            3.13
-            3.14
-          weights: |
-            1
-            1
-            1
-            1
+        # We should support major Python versions for at least 36 months as per SPEC 0
+        # We may be able to support pypy if anybody asks for it
+        # 3.9.16 0_73_pypy
+        run: |
+          choices=(3.11 3.12 3.13 3.14)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
       - name: RNG for source of python-suitesparse-graphblas
-        uses: ddradar/choose-random-action@v4.1.0
         id: sourcetype
-        with:
-          # Weights must be natural numbers, so set weights to very large to skip one
-          # (such as if 'upstream' is known to not work).
-          contents: |
-            conda-forge
-            wheel
-            source
-            upstream
-          weights: |
-            1
-            1
-            1
-            1
+        # Remove 'upstream' from the list if it is known to not work.
+        run: |
+          choices=(conda-forge wheel source upstream)
+          selected=${choices[$((RANDOM % ${#choices[@]}))]}
+          echo "selected: $selected (from: ${choices[*]})"
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         id: setup_conda


### PR DESCRIPTION
The rngs gate jobs and every build_and_test job resolved
ddradar/choose-random-action before starting, and GitHub's action
resolution service has been failing that lookup with repeated 5xx
errors ("Internal Server Error occurred while resolving
ddradar/choose-random-action@v4.1.0", also plain Service Unavailable).
A failure in a rngs job cancels everything gated behind it: the whole
11-job matrix in test_and_build.yml and the test_imports job in
imports.yml, which triggers on every pull request. Ten of the last ten
red Test runs died exactly there before running anything.

All six RNG steps (four in test_and_build.yml, two in imports.yml)
drew uniformly from small lists, which bash can do by itself: index an
array with RANDOM modulo its length. RANDOM is a bash builtin, so it
works in the ubuntu default shell, git-bash on Windows, and the bash
3.2 that macOS runners provide, and the jobs no longer download
anything to make their picks. Weighting a choice is now expressed by
repeating it in the list, and skipping one by removing it, which
replaces the action's natural-number weights mechanism (the old
comment about setting weights very large to skip an entry is gone with
it).

Verified: both workflows parse as YAML, the snippet produces uniform
draws under bash 3.2.57 (macOS's /bin/bash, with -e -u -o pipefail),
and no uses: of the action remain in any workflow.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>