### PR TITLE
Pin the CI interpreter and its ABI in the update-env step

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -195,6 +195,17 @@ jobs:
           echo "versions: np${npver} sp${spver} pd${pdver} ak${akver} nx${nxver} numba${numbaver} yaml${yamlver} sparse${sparsever} psg${psgver}"
 
           set -x  # echo on
+          # conda-forge ships two ABIs for CPython 3.13+, and this step did not
+          # restate ``python``, so the solver was free to replace the interpreter
+          # setup-miniconda installed: a 3.14 draw on ubuntu-24.04-arm became
+          # 3.14.7-*_cp314t, where pandas 2.3 raises a GIL RuntimeWarning that
+          # filterwarnings=error turns into a collection error. Restating the
+          # version pins the interpreter and ``python-gil`` pins python_abi to
+          # the GIL build; setup-miniconda's own ``python-version`` above is
+          # equally ABI-free, so this covers that step too.
+          # python-suitesparse-graphblas pins the same pair in
+          # .github/workflows/test.yml, and asks for python-freethreading on the
+          # matrix entries that want the other ABI.
           $(command -v mamba || command -v conda) install -c nodefaults \
             packaging pip pytest coverage pytest-randomly cffi donfig tomli c-compiler make \
             pyyaml${yamlver} ${sparse} pandas${pdver} scipy${spver} numpy${npver} ${awkward} \
@@ -204,6 +215,7 @@ jobs:
             ${{ steps.sourcetype.outputs.selected == 'upstream' && 'cython' || '' }} \
             ${{ steps.sourcetype.outputs.selected != 'wheel' && '"graphblas>=7.4"' || '' }} \
             ${{ contains(steps.pyver.outputs.selected, 'pypy') && 'pypy' || '' }} \
+            ${{ !contains(steps.pyver.outputs.selected, 'pypy') && format('python={0} python-gil', steps.pyver.outputs.selected) || '' }} \
             ${{ matrix.os == 'windows-latest' && 'cmake' || 'm4' }} \
             # ${{ matrix.os != 'windows-latest' && 'pytest-forked' || '' }}  # to investigate crashes
       - name: Build extension module


### PR DESCRIPTION
CI's "Update env" step did not restate `python`, so conda was free to replace the interpreter `setup-miniconda` had installed. Three of the last sixteen python 3.14 draws on `ubuntu-24.04-arm` did exactly that, swapping `3.14.7-*_cp314` for `3.14.7-*_cp314t`. Two survived only because they also drew pandas 3.0; the third drew pandas 2.3, whose extension raises a GIL `RuntimeWarning` on the free-threaded build, and `filterwarnings = error` turned it into a collection error that took `test_formatting.py` and `test_recorder.py` with it. That is the `ubuntu-24.04-arm` failure on #605.

Re-solving that job's own spec set per platform: `linux-aarch64` and `osx-arm64` both pick `cp314t` today, so `macos-latest` is on the same fuse and has just not drawn 3.14 with an unlucky pandas yet. `linux-64`, `osx-64` and `win-64` pick the GIL build either way.

The fix follows the precedent already in `python-suitesparse-graphblas` (`.github/workflows/test.yml`): pin the version and the ABI together. `python-gil` alone constrains only `python_abi` and leaves its own version open, so `python=` goes with it.

Checked before pushing:

* every platform lands on a `cp314` build with the pair added
* no draw becomes unsatisfiable and none downgrades numpy, numba, pandas or psg, including python 3.11 with numpy 1.24 and scipy 1.9
* `python-gil` has builds for 3.9 through 3.14, so one spec covers the whole pool, and it is a no-op on 3.11/3.12/3.13 today
* the pypy guard earns its place: `pypy python-gil` is unsatisfiable, so an unguarded spec would hard-fail a pypy draw if one is added back
* `actionlint` and the rest of `pre-commit run --all-files` pass

Not included: a deliberate `3.14t` matrix entry using `python-freethreading`, the way psg does it. That is worth having, but it is a coverage decision rather than a fix, and the pandas GIL warning would need handling on that entry.

One place left unpinned: `docs/env.yml` (used by readthedocs) asks for `python=3.13` with no ABI spec. It resolves to `cp313` today, so nothing is broken, but it is the last conda-solved interpreter in the repo.